### PR TITLE
Make value immutable for all scalars with scratch space

### DIFF
--- a/c_glib/arrow-glib/scalar.cpp
+++ b/c_glib/arrow-glib/scalar.cpp
@@ -1984,7 +1984,8 @@ garrow_base_list_scalar_get_value(GArrowBaseListScalar *scalar)
   if (!priv->value) {
     const auto arrow_scalar = std::static_pointer_cast<arrow::BaseListScalar>(
       garrow_scalar_get_raw(GARROW_SCALAR(scalar)));
-    priv->value = garrow_array_new_raw(&(arrow_scalar->value));
+    priv->value = garrow_array_new_raw(
+      const_cast<std::shared_ptr<arrow::Buffer> *>(&(arrow_scalar->value)));
   }
   return priv->value;
 }

--- a/c_glib/arrow-glib/scalar.cpp
+++ b/c_glib/arrow-glib/scalar.cpp
@@ -1985,7 +1985,7 @@ garrow_base_list_scalar_get_value(GArrowBaseListScalar *scalar)
     const auto arrow_scalar = std::static_pointer_cast<arrow::BaseListScalar>(
       garrow_scalar_get_raw(GARROW_SCALAR(scalar)));
     priv->value = garrow_array_new_raw(
-      const_cast<std::shared_ptr<arrow::Buffer> *>(&(arrow_scalar->value)));
+      const_cast<std::shared_ptr<arrow::Array> *>(&(arrow_scalar->value)));
   }
   return priv->value;
 }

--- a/cpp/src/arrow/scalar.cc
+++ b/cpp/src/arrow/scalar.cc
@@ -816,7 +816,8 @@ SparseUnionScalar::SparseUnionScalar(ValueType value, int8_t type_code,
     : UnionScalar(std::move(type), type_code, /*is_valid=*/true),
       value(std::move(value)) {
   const auto child_ids = checked_cast<const SparseUnionType&>(*this->type).child_ids();
-  if (type_code >= 0 && static_cast<size_t>(type_code) < child_ids.size()) {
+  if (type_code >= 0 && static_cast<size_t>(type_code) < child_ids.size() &&
+      child_ids[type_code] != UnionType::kInvalidChildId) {
     this->child_id = child_ids[type_code];
 
     // Fix nullness based on whether the selected child is null

--- a/cpp/src/arrow/scalar.cc
+++ b/cpp/src/arrow/scalar.cc
@@ -617,7 +617,9 @@ FixedSizeBinaryScalar::FixedSizeBinaryScalar(std::string s, bool is_valid)
 BaseListScalar::BaseListScalar(std::shared_ptr<Array> value,
                                std::shared_ptr<DataType> type, bool is_valid)
     : Scalar{std::move(type), is_valid}, value(std::move(value)) {
-  ARROW_CHECK(this->type->field(0)->type()->Equals(this->value->type()));
+  if (this->value) {
+    ARROW_CHECK(this->type->field(0)->type()->Equals(this->value->type()));
+  }
 }
 
 ListScalar::ListScalar(std::shared_ptr<Array> value, bool is_valid)
@@ -669,8 +671,10 @@ void MapScalar::FillScratchSpace() {
 FixedSizeListScalar::FixedSizeListScalar(std::shared_ptr<Array> value,
                                          std::shared_ptr<DataType> type, bool is_valid)
     : BaseListScalar(std::move(value), std::move(type), is_valid) {
-  ARROW_CHECK_EQ(this->value->length(),
-                 checked_cast<const FixedSizeListType&>(*this->type).list_size());
+  if (value) {
+    ARROW_CHECK_EQ(this->value->length(),
+                   checked_cast<const FixedSizeListType&>(*this->type).list_size());
+  }
 }
 
 FixedSizeListScalar::FixedSizeListScalar(std::shared_ptr<Array> value, bool is_valid)
@@ -811,11 +815,13 @@ SparseUnionScalar::SparseUnionScalar(ValueType value, int8_t type_code,
                                      std::shared_ptr<DataType> type)
     : UnionScalar(std::move(type), type_code, /*is_valid=*/true),
       value(std::move(value)) {
-  this->child_id =
-      checked_cast<const SparseUnionType&>(*this->type).child_ids()[type_code];
+  const auto child_ids = checked_cast<const SparseUnionType&>(*this->type).child_ids();
+  if (type_code >= 0 && static_cast<size_t>(type_code) < child_ids.size()) {
+    this->child_id = child_ids[type_code];
 
-  // Fix nullness based on whether the selected child is null
-  this->is_valid = this->value[this->child_id]->is_valid;
+    // Fix nullness based on whether the selected child is null
+    this->is_valid = this->value[this->child_id]->is_valid;
+  }
 }
 
 std::shared_ptr<Scalar> SparseUnionScalar::FromValue(std::shared_ptr<Scalar> value,

--- a/cpp/src/arrow/scalar.h
+++ b/cpp/src/arrow/scalar.h
@@ -540,13 +540,12 @@ struct ARROW_EXPORT Decimal256Scalar : public DecimalScalar<Decimal256Type, Deci
 };
 
 struct ARROW_EXPORT BaseListScalar : public Scalar {
-  using Scalar::Scalar;
   using ValueType = std::shared_ptr<Array>;
 
   BaseListScalar(std::shared_ptr<Array> value, std::shared_ptr<DataType> type,
                  bool is_valid = true);
 
-  std::shared_ptr<Array> value;
+  const std::shared_ptr<Array> value;
 };
 
 struct ARROW_EXPORT ListScalar
@@ -659,7 +658,7 @@ struct ARROW_EXPORT StructScalar : public Scalar {
 };
 
 struct ARROW_EXPORT UnionScalar : public Scalar {
-  int8_t type_code;
+  const int8_t type_code;
 
   virtual const std::shared_ptr<Scalar>& child_value() const = 0;
 
@@ -687,7 +686,7 @@ struct ARROW_EXPORT SparseUnionScalar
   // nonetheless construct a vector of scalars, one per union value, to have
   // enough data to reconstruct a valid ArraySpan of length 1 from this scalar
   using ValueType = std::vector<std::shared_ptr<Scalar>>;
-  ValueType value;
+  const ValueType value;
 
   // The value index corresponding to the active type code
   int child_id;
@@ -720,7 +719,7 @@ struct ARROW_EXPORT DenseUnionScalar
   // For DenseUnionScalar, we can make a valid ArraySpan of length 1 from this
   // scalar
   using ValueType = std::shared_ptr<Scalar>;
-  ValueType value;
+  const ValueType value;
 
   const std::shared_ptr<Scalar>& child_value() const override { return this->value; }
 
@@ -743,7 +742,7 @@ struct ARROW_EXPORT RunEndEncodedScalar
   using ArraySpanFillFromScalarScratchSpace =
       internal::ArraySpanFillFromScalarScratchSpace<RunEndEncodedScalar>;
 
-  ValueType value;
+  const ValueType value;
 
   RunEndEncodedScalar(std::shared_ptr<Scalar> value, std::shared_ptr<DataType> type);
 

--- a/cpp/src/arrow/scalar_test.cc
+++ b/cpp/src/arrow/scalar_test.cc
@@ -1167,24 +1167,25 @@ class TestListLikeScalar : public ::testing::Test {
   }
 
   void TestValidateErrors() {
-    ScalarType scalar(value_);
-    scalar.is_valid = false;
-    ASSERT_OK(scalar.ValidateFull());
+    {
+      ScalarType scalar(value_);
+      scalar.is_valid = false;
+      ASSERT_OK(scalar.ValidateFull());
+    }
 
-    // Value must be defined
-    scalar = ScalarType(value_);
-    scalar.value = nullptr;
-    AssertValidationFails(scalar);
+    {
+      // Value must be defined
+      ScalarType scalar(nullptr, type_);
+      scalar.is_valid = true;
+      AssertValidationFails(scalar);
+    }
 
-    // Inconsistent child type
-    scalar = ScalarType(value_);
-    scalar.value = ArrayFromJSON(int32(), "[1, 2, null]");
-    AssertValidationFails(scalar);
-
-    // Invalid UTF8 in child data
-    scalar = ScalarType(ArrayFromJSON(utf8(), "[null, null, \"\xff\"]"));
-    ASSERT_OK(scalar.Validate());
-    ASSERT_RAISES(Invalid, scalar.ValidateFull());
+    {
+      // Invalid UTF8 in child data
+      ScalarType scalar(ArrayFromJSON(utf8(), "[null, null, \"\xff\"]"));
+      ASSERT_OK(scalar.Validate());
+      ASSERT_RAISES(Invalid, scalar.ValidateFull());
+    }
   }
 
   void TestHashing() {
@@ -1565,17 +1566,41 @@ void CheckGetNullUnionScalar(const Array& arr, int64_t index) {
   ASSERT_FALSE(checked_cast<const UnionScalar&>(*scalar).child_value()->is_valid);
 }
 
+std::shared_ptr<Scalar> MakeUnionScalar(const SparseUnionType& type, int8_t type_code,
+                                        std::shared_ptr<Scalar> field_value,
+                                        int field_index) {
+  ScalarVector field_values;
+  for (int i = 0; i < type.num_fields(); ++i) {
+    if (i == field_index) {
+      field_values.emplace_back(std::move(field_value));
+    } else {
+      field_values.emplace_back(MakeNullScalar(type.field(i)->type()));
+    }
+  }
+  return std::make_shared<SparseUnionScalar>(std::move(field_values), type_code,
+                                             type.GetSharedPtr());
+}
+
 std::shared_ptr<Scalar> MakeUnionScalar(const SparseUnionType& type,
                                         std::shared_ptr<Scalar> field_value,
                                         int field_index) {
-  return SparseUnionScalar::FromValue(field_value, field_index, type.GetSharedPtr());
+  return SparseUnionScalar::FromValue(std::move(field_value), field_index,
+                                      type.GetSharedPtr());
+}
+
+std::shared_ptr<Scalar> MakeUnionScalar(const DenseUnionType& type, int8_t type_code,
+                                        std::shared_ptr<Scalar> field_value,
+                                        int field_index) {
+  return std::make_shared<DenseUnionScalar>(std::move(field_value), type_code,
+                                            type.GetSharedPtr());
 }
 
 std::shared_ptr<Scalar> MakeUnionScalar(const DenseUnionType& type,
                                         std::shared_ptr<Scalar> field_value,
                                         int field_index) {
   int8_t type_code = type.type_codes()[field_index];
-  return std::make_shared<DenseUnionScalar>(field_value, type_code, type.GetSharedPtr());
+  return std::make_shared<DenseUnionScalar>(std::move(field_value), type_code,
+                                            type.GetSharedPtr());
 }
 
 std::shared_ptr<Scalar> MakeSpecificNullScalar(const DenseUnionType& type,
@@ -1623,7 +1648,13 @@ class TestUnionScalar : public ::testing::Test {
 
   std::shared_ptr<Scalar> ScalarFromValue(int field_index,
                                           std::shared_ptr<Scalar> field_value) {
-    return MakeUnionScalar(*union_type_, field_value, field_index);
+    return MakeUnionScalar(*union_type_, std::move(field_value), field_index);
+  }
+
+  std::shared_ptr<Scalar> ScalarFromTypeCodeAndValue(int8_t type_code,
+                                                     std::shared_ptr<Scalar> field_value,
+                                                     int field_index) {
+    return MakeUnionScalar(*union_type_, type_code, std::move(field_value), field_index);
   }
 
   std::shared_ptr<Scalar> SpecificNull(int field_index) {
@@ -1641,40 +1672,48 @@ class TestUnionScalar : public ::testing::Test {
   }
 
   void TestValidateErrors() {
-    // Type code doesn't exist
-    auto scalar = ScalarFromValue(0, alpha_);
-    UnionScalar* union_scalar = static_cast<UnionScalar*>(scalar.get());
+    {
+      // Invalid type code
+      auto scalar = ScalarFromTypeCodeAndValue(0, alpha_, 0);
+      AssertValidationFails(*scalar);
+    }
 
-    // Invalid type code
-    union_scalar->type_code = 0;
-    AssertValidationFails(*union_scalar);
+    {
+      auto scalar = ScalarFromTypeCodeAndValue(0, alpha_, 0);
+      scalar->is_valid = false;
+      AssertValidationFails(*scalar);
+    }
 
-    union_scalar->is_valid = false;
-    AssertValidationFails(*union_scalar);
+    {
+      auto scalar = ScalarFromTypeCodeAndValue(-42, alpha_, 0);
+      AssertValidationFails(*scalar);
+    }
 
-    union_scalar->type_code = -42;
-    union_scalar->is_valid = true;
-    AssertValidationFails(*union_scalar);
-
-    union_scalar->is_valid = false;
-    AssertValidationFails(*union_scalar);
+    {
+      auto scalar = ScalarFromTypeCodeAndValue(-42, alpha_, 0);
+      scalar->is_valid = false;
+      AssertValidationFails(*scalar);
+    }
 
     // Type code doesn't correspond to child type
     if (type_->id() == ::arrow::Type::DENSE_UNION) {
-      union_scalar->type_code = 42;
-      union_scalar->is_valid = true;
-      AssertValidationFails(*union_scalar);
+      {
+        auto scalar = ScalarFromTypeCodeAndValue(42, alpha_, 0);
+        AssertValidationFails(*scalar);
+      }
 
-      scalar = ScalarFromValue(2, two_);
-      union_scalar = static_cast<UnionScalar*>(scalar.get());
-      union_scalar->type_code = 3;
-      AssertValidationFails(*union_scalar);
+      {
+        auto scalar = ScalarFromTypeCodeAndValue(3, two_, 2);
+        AssertValidationFails(*scalar);
+      }
     }
 
-    // underlying value has invalid UTF8
-    scalar = ScalarFromValue(0, std::make_shared<StringScalar>("\xff"));
-    ASSERT_OK(scalar->Validate());
-    ASSERT_RAISES(Invalid, scalar->ValidateFull());
+    {
+      // underlying value has invalid UTF8
+      auto scalar = ScalarFromValue(0, std::make_shared<StringScalar>("\xff"));
+      ASSERT_OK(scalar->Validate());
+      ASSERT_RAISES(Invalid, scalar->ValidateFull());
+    }
   }
 
   void TestEquals() {


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->