### PR TITLE
Fix the issue that comparison function could not handle decimal arguments with different scales

### DIFF
--- a/cpp/src/arrow/compute/expression_test.cc
+++ b/cpp/src/arrow/compute/expression_test.cc
@@ -648,6 +648,10 @@ TEST(Expression, BindWithDecimalArithmeticOps) {
 }
 
 TEST(Expression, BindWithImplicitCasts) {
+  auto exciting_schema = schema(
+      {field("i64", int64()), field("dec128_3_2", decimal128(3, 2)),
+       field("dec128_5_3", decimal128(5, 3)), field("dec256_3_2", decimal256(3, 2)),
+       field("dec256_5_3", decimal256(5, 3))});
   for (auto cmp : {equal, not_equal, less, less_equal, greater, greater_equal}) {
     // cast arguments to common numeric type
     ExpectBindsTo(cmp(field_ref("i64"), field_ref("i32")),
@@ -708,6 +712,42 @@ TEST(Expression, BindWithImplicitCasts) {
     ExpectBindsTo(cmp(field_ref("i32"), literal(std::make_shared<DoubleScalar>(10.0))),
                   cmp(cast(field_ref("i32"), float32()),
                       literal(std::make_shared<FloatScalar>(10.0f))));
+
+    // decimal int
+    ExpectBindsTo(cmp(field_ref("dec128_3_2"), field_ref("i64")),
+                  cmp(field_ref("dec128_3_2"), cast(field_ref("i64"), decimal128(21, 2))),
+                  /*bound_out=*/nullptr, *exciting_schema);
+    ExpectBindsTo(cmp(field_ref("i64"), field_ref("dec128_3_2")),
+                  cmp(cast(field_ref("i64"), decimal128(21, 2)), field_ref("dec128_3_2")),
+                  /*bound_out=*/nullptr, *exciting_schema);
+
+    // decimal128 decimal256 with different scales
+    ExpectBindsTo(
+        cmp(field_ref("dec128_3_2"), field_ref("dec256_5_3")),
+        cmp(cast(field_ref("dec128_3_2"), decimal256(4, 3)), field_ref("dec256_5_3")),
+        /*bound_out=*/nullptr, *exciting_schema);
+    ExpectBindsTo(
+        cmp(field_ref("dec256_5_3"), field_ref("dec128_3_2")),
+        cmp(field_ref("dec256_5_3"), cast(field_ref("dec128_3_2"), decimal256(4, 3))),
+        /*bound_out=*/nullptr, *exciting_schema);
+    ExpectBindsTo(cmp(field_ref("dec128_5_3"), field_ref("dec256_3_2")),
+                  cmp(cast(field_ref("dec128_5_3"), decimal256(5, 3)),
+                      cast(field_ref("dec256_3_2"), decimal256(4, 3))),
+                  /*bound_out=*/nullptr, *exciting_schema);
+    ExpectBindsTo(cmp(field_ref("dec256_3_2"), field_ref("dec128_5_3")),
+                  cmp(cast(field_ref("dec256_3_2"), decimal256(4, 3)),
+                      cast(field_ref("dec128_5_3"), decimal256(5, 3))),
+                  /*bound_out=*/nullptr, *exciting_schema);
+
+    // decimal decimal with different scales
+    ExpectBindsTo(
+        cmp(field_ref("dec128_3_2"), field_ref("dec128_5_3")),
+        cmp(cast(field_ref("dec128_3_2"), decimal128(4, 3)), field_ref("dec128_5_3")),
+        /*bound_out=*/nullptr, *exciting_schema);
+    ExpectBindsTo(
+        cmp(field_ref("dec128_5_3"), field_ref("dec128_3_2")),
+        cmp(field_ref("dec128_5_3"), cast(field_ref("dec128_3_2"), decimal128(4, 3))),
+        /*bound_out=*/nullptr, *exciting_schema);
   }
 
   compute::SetLookupOptions in_a{ArrayFromJSON(utf8(), R"(["a"])")};

--- a/cpp/src/arrow/compute/kernels/scalar_compare.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare.cc
@@ -436,8 +436,8 @@ std::shared_ptr<ScalarFunction> MakeCompareFunction(std::string name, FunctionDo
 
   for (const auto id : {Type::DECIMAL128, Type::DECIMAL256}) {
     auto exec = GenerateDecimal<applicator::ScalarBinaryEqualTypes, BooleanType, Op>(id);
-    DCHECK_OK(
-        func->AddKernel({InputType(id), InputType(id)}, boolean(), std::move(exec)));
+    DCHECK_OK(func->AddKernel({InputType(id), InputType(id)}, boolean(), std::move(exec),
+                              /*init=*/nullptr, DecimalsHaveSameScale()));
   }
 
   {


### PR DESCRIPTION
apache#47378)

### Rationale for this change

In order to support special form (apache#47374), the kernels have to respect the selection vector. Currently none of the kernels does. And it's almost impossible for us to make all existing kernels to respect the selection vector at once (and we probably never will). Thus we need an incremental way to add selection-vector-aware kernels on demand, meanwhile accommodate legacy (selection-vector-non-aware) kernels to be executed "selection-vector-aware"-ly in a general manner - the idea is to first "gather" selected rows from the batch into a new batch, evaluate the expression on the new batch, then "scatter" the result rows into the positions where they belong in the original batch.

This makes the `take` and `scatter` functions dependencies of the exec facilities, which is in compute core (libarrow). And `take` is already in compute core. Now we need to move `scatter`.

I'm implementing the selective execution of kernels in apache#47377, including invoking `take` and `scatter` as explained above. And I have to write tests of that in `exec_test.cc` which is deliberately declared to be NOT depending on libarrow_compute.

### What changes are included in this PR?

Move scatter compute function into compute core.

### Are these changes tested?

Yes. Manually tested.

### Are there any user-facing changes?

None.
* GitHub Issue: apache#47375

Authored-by: Rossi Sun <zanmato1984@gmail.com>
Signed-off-by: Rossi Sun <zanmato1984@gmail.com>Thanks for opening a pull request!

If this is your first pull request you can find detailed information on how to contribute here:

  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)

Please remove this line and the above text before creating your pull request.

### Rationale for this change

### What changes are included in this PR?

### Are these changes tested?

### Are there any user-facing changes?

**This PR includes breaking changes to public APIs.** (If there are any breaking changes to public APIs, please explain which changes are breaking. If not, you can remove this.)

**This PR contains a "Critical Fix".** (If the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld), please provide explanation. If not, you can remove this.)
