### PR TITLE
GH-49392: [C++][Compute] Fix fixed-width gather byte offset overflow

### DIFF
--- a/cpp/src/arrow/compute/kernels/gather_internal.h
+++ b/cpp/src/arrow/compute/kernels/gather_internal.h
@@ -35,6 +35,11 @@
 
 namespace arrow::internal {
 
+template <typename IndexType>
+constexpr int64_t FixedWidthByteOffset(IndexType index, int64_t value_width) {
+  return static_cast<int64_t>(index) * value_width;
+}
+
 // CRTP [1] base class for Gather that provides a gathering loop in terms of
 // Write*() methods that must be implemented by the derived class.
 //
@@ -185,8 +190,8 @@ class Gather : public GatherBaseCRTP<Gather<kValueWidthInBits, IndexCType, kWith
       memcpy(out_ + position * scaled_factor, src_ + idx_[position] * scaled_factor,
              scaled_factor);
     } else {
-      memcpy(out_ + position * kValueWidth, src_ + idx_[position] * kValueWidth,
-             kValueWidth);
+      memcpy(out_ + FixedWidthByteOffset(position, kValueWidth),
+             src_ + FixedWidthByteOffset(idx_[position], kValueWidth), kValueWidth);
     }
   }
 
@@ -195,7 +200,7 @@ class Gather : public GatherBaseCRTP<Gather<kValueWidthInBits, IndexCType, kWith
       const int64_t scaled_factor = kValueWidth * factor_;
       memset(out_ + position * scaled_factor, 0, scaled_factor);
     } else {
-      memset(out_ + position * kValueWidth, 0, kValueWidth);
+      memset(out_ + FixedWidthByteOffset(position, kValueWidth), 0, kValueWidth);
     }
   }
 
@@ -204,7 +209,8 @@ class Gather : public GatherBaseCRTP<Gather<kValueWidthInBits, IndexCType, kWith
       const int64_t scaled_factor = kValueWidth * factor_;
       memset(out_ + position * scaled_factor, 0, length * scaled_factor);
     } else {
-      memset(out_ + position * kValueWidth, 0, length * kValueWidth);
+      memset(out_ + FixedWidthByteOffset(position, kValueWidth), 0,
+             FixedWidthByteOffset(length, kValueWidth));
     }
   }
 

--- a/cpp/src/arrow/compute/kernels/vector_selection_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_test.cc
@@ -27,6 +27,7 @@
 #include "arrow/array/concatenate.h"
 #include "arrow/chunked_array.h"
 #include "arrow/compute/api.h"
+#include "arrow/compute/kernels/gather_internal.h"
 #include "arrow/compute/kernels/test_util_internal.h"
 #include "arrow/scalar.h"
 #include "arrow/table.h"
@@ -103,6 +104,18 @@ void CheckTakeIndicesCase(const std::string& filter_json, const std::string& ind
 }
 
 }  // namespace
+
+// GH-49392: Fixed-width gather byte offsets must be computed in int64_t.
+TEST(GatherInternal, FixedWidthByteOffsetUses64BitArithmetic) {
+  constexpr int64_t kByteWidth = 8;
+  constexpr uint32_t kIndex = std::numeric_limits<uint32_t>::max() / kByteWidth + 1;
+  constexpr int64_t kExpectedByteOffset =
+      static_cast<int64_t>(std::numeric_limits<uint32_t>::max()) + 1;
+
+  const int64_t byte_offset = ::arrow::internal::FixedWidthByteOffset(kIndex, kByteWidth);
+  ASSERT_EQ(byte_offset, kExpectedByteOffset);
+  ASSERT_GT(byte_offset, std::numeric_limits<uint32_t>::max());
+}
 
 // ----------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- fix fixed-width gather byte offset calculations to use 64-bit arithmetic for large uint32 indices
- add a regression test that covers the large-index byte-offset computation behind the reported list filter corruption

## Root cause
When `Table.filter()` builds child indices for a large `list<double>` column, the fixed-width gather path later multiplies a `uint32` index by the value byte width. That multiplication was performed in 32-bit arithmetic, so large child positions wrapped before pointer arithmetic and the wrong values were gathered.

## Testing
- `./cpp/build/case-49392/debug/arrow-compute-vector-selection-test`

Closes apache/arrow#49392
