### PR TITLE
GH-49272: Include windows_compatibility.h in thread_pool_test

### DIFF
--- a/cpp/src/arrow/util/thread_pool_test.cc
+++ b/cpp/src/arrow/util/thread_pool_test.cc
@@ -44,6 +44,7 @@
 #include "arrow/util/macros.h"
 #include "arrow/util/test_common.h"
 #include "arrow/util/thread_pool.h"
+#include "arrow/util/windows_compatibility.h"
 
 namespace arrow {
 namespace internal {


### PR DESCRIPTION
## Summary
- add the missing `arrow/util/windows_compatibility.h` include to `cpp/src/arrow/util/thread_pool_test.cc`
- keep the new Windows `GetLastError()` regression test buildable when it references `SetLastError`, `GetLastError`, `DWORD`, and `ERROR_*`
- follow up on apache/arrow#49462 without modifying the contributor branch

## Context
This is a small follow-up branch for apache/arrow#49462. The upstream PR already adds the Windows last-error preservation logic and the new regression test; this branch only supplies the missing compatibility include needed by that test.

## Validation
- `./debug/arrow-json-test --gtest_filter=ReaderTest.MultipleChunksParallelRegression`
- `./debug/arrow-threading-utility-test --gtest_filter=TestThreadPool.*Owns*`
