### PR TITLE
Draft: SelectionSpan + 64-bit selection indices

### DIFF
--- a/cpp/src/arrow/compute/exec.cc
+++ b/cpp/src/arrow/compute/exec.cc
@@ -313,6 +313,14 @@ void ComputeDataPreallocate(const DataType& type,
 
 namespace detail {
 
+// Lambda helper & CTAD (C++17)
+template <class... Ts>
+struct overloaded : Ts... {
+  using Ts::operator()...;
+};
+template <class... Ts>
+overloaded(Ts...)->overloaded<Ts...>;
+
 // ----------------------------------------------------------------------
 // ExecSpanIterator
 
@@ -957,6 +965,15 @@ class ScalarExecutor : public KernelExecutorImpl<ScalarKernel> {
       while (span_iterator_.Next(&input, selection_ptr)) {
         // Set absolute output span position and length
         output_span->SetSlice(result_offset, input.length);
+        if (selection_ptr != nullptr) {
+          const int64_t selected_count = SelectedCount(*selection_ptr);
+          if (selected_count == 0) {
+            // No rows are selected in this span; output must be all-null.
+            SetSpanAllNull(output_span);
+            result_offset = span_iterator_.position();
+            continue;
+          }
+        }
         RETURN_NOT_OK(ExecuteSingleSpan(input, selection_ptr, &output));
         result_offset = span_iterator_.position();
       }
@@ -991,6 +1008,9 @@ class ScalarExecutor : public KernelExecutorImpl<ScalarKernel> {
       result_span->null_count = 0;
     }
     RETURN_NOT_OK(ExecuteKernel(input, selection, out));
+    if (selection != nullptr) {
+      RETURN_NOT_OK(ApplySelectionMask(*selection, result_span));
+    }
     // Output type didn't change
     DCHECK(out->is_array_span());
     return Status::OK();
@@ -1012,6 +1032,15 @@ class ScalarExecutor : public KernelExecutorImpl<ScalarKernel> {
     }
     ExecResult output;
     while (span_iterator_.Next(&input, selection_ptr)) {
+      if (selection_ptr != nullptr && SelectedCount(*selection_ptr) == 0) {
+        // No rows are selected in this span; output must be all-null.
+        ARROW_ASSIGN_OR_RAISE(
+            std::shared_ptr<Array> all_null,
+            MakeArrayOfNull(output_type_.GetSharedPtr(), input.length,
+                            exec_context()->memory_pool()));
+        RETURN_NOT_OK(EmitResult(all_null->data(), listener));
+        continue;
+      }
       ARROW_ASSIGN_OR_RAISE(output.value, PrepareOutput(input.length));
       DCHECK(output.is_array_data());
 
@@ -1028,6 +1057,10 @@ class ScalarExecutor : public KernelExecutorImpl<ScalarKernel> {
 
       // Output type didn't change
       DCHECK(output.is_array_data());
+
+      if (selection_ptr != nullptr) {
+        RETURN_NOT_OK(ApplySelectionMask(*selection_ptr, out_arr));
+      }
 
       // Emit a result for each chunk
       RETURN_NOT_OK(EmitResult(output.array_data(), listener));
@@ -1059,6 +1092,18 @@ class ScalarExecutor : public KernelExecutorImpl<ScalarKernel> {
       } else if (kernel_->null_handling == NullHandling::OUTPUT_NOT_NULL) {
         elide_validity_bitmap_ = true;
       }
+    }
+
+    // A selection may introduce nulls even if the kernel itself does not.
+    // When a batch has a selection vector, rows outside the selection must be null.
+    const bool selection_may_introduce_nulls =
+        span_iterator_.have_selection_vector() &&
+        span_iterator_.selection_length() != span_iterator_.length() &&
+        !output_type_.type->layout().buffers.empty() &&
+        output_type_.type->layout().buffers[0].kind == DataTypeLayout::BITMAP;
+    if (selection_may_introduce_nulls) {
+      elide_validity_bitmap_ = false;
+      validity_preallocated_ = true;
     }
     if (kernel_->mem_allocation == MemAllocation::PREALLOCATE) {
       data_preallocated_.clear();
@@ -1116,6 +1161,189 @@ class ScalarExecutor : public KernelExecutorImpl<ScalarKernel> {
   bool preallocate_contiguous_ = false;
 
   ExecSpanIterator span_iterator_;
+
+  static int64_t SelectedCount(const ContiguousSpan& span) { return span.length; }
+  static int64_t SelectedCount(const DiscreteSpan& span) { return span.length; }
+  static int64_t SelectedCount(const FilteredSpan& span) {
+    DCHECK_NE(span.bitmap, nullptr);
+    return ::arrow::internal::CountSetBits(span.bitmap, span.bitmap_offset, span.length);
+  }
+  static int64_t SelectedCount(const SelectionSpan& selection) {
+    return std::visit([](const auto& span) { return SelectedCount(span); }, selection);
+  }
+
+  static void SetSpanAllNull(ArraySpan* out) {
+    out->null_count = out->length;
+    if (!out->type->layout().buffers.empty() &&
+        out->type->layout().buffers[0].kind == DataTypeLayout::BITMAP &&
+        out->buffers[0].data != nullptr) {
+      bit_util::SetBitsTo(out->buffers[0].data, out->offset, out->length, false);
+    }
+  }
+
+  Status ApplySelectionMask(const SelectionSpan& selection, ArraySpan* out) {
+    if (out->length == 0) {
+      return Status::OK();
+    }
+    if (output_type_.type->layout().buffers.empty() ||
+        output_type_.type->layout().buffers[0].kind != DataTypeLayout::BITMAP) {
+      // Types without a top-level validity bitmap (e.g. unions) are not yet
+      // handled here.
+      return Status::OK();
+    }
+    const int64_t selected_count = SelectedCount(selection);
+    if (selected_count == out->length) {
+      return Status::OK();
+    }
+    uint8_t* out_bitmap = out->buffers[0].data;
+    DCHECK_NE(out_bitmap, nullptr);
+
+    const int64_t base = out->offset;
+    const int64_t len = out->length;
+
+    if (kernel_->null_handling == NullHandling::OUTPUT_NOT_NULL) {
+      // The kernel promises all selected rows are valid; only the selection introduces
+      // nulls.
+      bit_util::SetBitsTo(out_bitmap, base, len, false);
+      VisitSelectionSpanInline(selection,
+                               [&](int64_t i) { bit_util::SetBit(out_bitmap, base + i); });
+      out->null_count = len - selected_count;
+      return Status::OK();
+    }
+
+    return std::visit(
+        overloaded{
+            [&](const ContiguousSpan& span) -> Status {
+              if (span.start_offset > 0) {
+                bit_util::SetBitsTo(out_bitmap, base, span.start_offset, false);
+              }
+              const int64_t end = span.start_offset + span.length;
+              if (end < len) {
+                bit_util::SetBitsTo(out_bitmap, base + end, len - end, false);
+              }
+              out->null_count = kUnknownNullCount;
+              return Status::OK();
+            },
+            [&](const FilteredSpan& span) -> Status {
+              DCHECK_NE(span.bitmap, nullptr);
+              if (span.start_offset > 0) {
+                bit_util::SetBitsTo(out_bitmap, base, span.start_offset, false);
+              }
+              const int64_t end = span.start_offset + span.length;
+              if (end < len) {
+                bit_util::SetBitsTo(out_bitmap, base + end, len - end, false);
+              }
+              BitmapAnd(out_bitmap, base + span.start_offset, span.bitmap, span.bitmap_offset,
+                        span.length, base + span.start_offset, out_bitmap);
+              out->null_count = kUnknownNullCount;
+              return Status::OK();
+            },
+            [&](const DiscreteSpan& span) -> Status {
+              // Clear only non-selected ranges, preserving selected validity.
+              int64_t cursor = 0;
+              for (int64_t i = 0; i < span.length; ++i) {
+                const int64_t idx = span[i];
+                DCHECK_GE(idx, 0);
+                DCHECK_LT(idx, len);
+                if (idx > cursor) {
+                  bit_util::SetBitsTo(out_bitmap, base + cursor, idx - cursor, false);
+                }
+                cursor = idx + 1;
+              }
+              if (cursor < len) {
+                bit_util::SetBitsTo(out_bitmap, base + cursor, len - cursor, false);
+              }
+              out->null_count = kUnknownNullCount;
+              return Status::OK();
+            }},
+        selection);
+  }
+
+  Status ApplySelectionMask(const SelectionSpan& selection, ArrayData* out) {
+    if (out->length == 0) {
+      return Status::OK();
+    }
+    if (out->type->layout().buffers.empty() ||
+        out->type->layout().buffers[0].kind != DataTypeLayout::BITMAP) {
+      return Status::OK();
+    }
+    if (out->buffers.empty()) {
+      return Status::OK();
+    }
+    if (out->buffers[0] == nullptr) {
+      // A missing validity bitmap implies "all valid". Materialize an all-valid bitmap so
+      // we can mask it with the selection.
+      const int64_t bitmap_length = out->offset + out->length;
+      ARROW_ASSIGN_OR_RAISE(out->buffers[0],
+                            AllocateEmptyBitmap(bitmap_length, exec_context()->memory_pool()));
+      bit_util::SetBitsTo(out->buffers[0]->mutable_data(), /*start_offset=*/0,
+                          bitmap_length, true);
+      out->null_count = 0;
+    }
+
+    const int64_t selected_count = SelectedCount(selection);
+    if (selected_count == out->length) {
+      return Status::OK();
+    }
+
+    uint8_t* out_bitmap = out->buffers[0]->mutable_data();
+    const int64_t base = out->offset;
+    const int64_t len = out->length;
+
+    if (kernel_->null_handling == NullHandling::OUTPUT_NOT_NULL) {
+      bit_util::SetBitsTo(out_bitmap, base, len, false);
+      VisitSelectionSpanInline(selection,
+                               [&](int64_t i) { bit_util::SetBit(out_bitmap, base + i); });
+      out->null_count = len - selected_count;
+      return Status::OK();
+    }
+
+    return std::visit(
+        overloaded{
+            [&](const ContiguousSpan& span) -> Status {
+              if (span.start_offset > 0) {
+                bit_util::SetBitsTo(out_bitmap, base, span.start_offset, false);
+              }
+              const int64_t end = span.start_offset + span.length;
+              if (end < len) {
+                bit_util::SetBitsTo(out_bitmap, base + end, len - end, false);
+              }
+              out->null_count = kUnknownNullCount;
+              return Status::OK();
+            },
+            [&](const FilteredSpan& span) -> Status {
+              DCHECK_NE(span.bitmap, nullptr);
+              if (span.start_offset > 0) {
+                bit_util::SetBitsTo(out_bitmap, base, span.start_offset, false);
+              }
+              const int64_t end = span.start_offset + span.length;
+              if (end < len) {
+                bit_util::SetBitsTo(out_bitmap, base + end, len - end, false);
+              }
+              BitmapAnd(out_bitmap, base + span.start_offset, span.bitmap, span.bitmap_offset,
+                        span.length, base + span.start_offset, out_bitmap);
+              out->null_count = kUnknownNullCount;
+              return Status::OK();
+            },
+            [&](const DiscreteSpan& span) -> Status {
+              int64_t cursor = 0;
+              for (int64_t i = 0; i < span.length; ++i) {
+                const int64_t idx = span[i];
+                DCHECK_GE(idx, 0);
+                DCHECK_LT(idx, len);
+                if (idx > cursor) {
+                  bit_util::SetBitsTo(out_bitmap, base + cursor, idx - cursor, false);
+                }
+                cursor = idx + 1;
+              }
+              if (cursor < len) {
+                bit_util::SetBitsTo(out_bitmap, base + cursor, len - cursor, false);
+              }
+              out->null_count = kUnknownNullCount;
+              return Status::OK();
+            }},
+        selection);
+  }
 };
 
 namespace {

--- a/cpp/src/arrow/compute/exec.cc
+++ b/cpp/src/arrow/compute/exec.cc
@@ -1193,38 +1193,47 @@ class ScalarExecutor : public KernelExecutorImpl<ScalarKernel> {
     }
   }
 
-  Status ApplySelectionMask(const SelectionSpan& selection, ArraySpan* out) {
-    if (out->length == 0) {
-      return Status::OK();
-    }
-    if (output_type_.type->layout().buffers.empty() ||
-        output_type_.type->layout().buffers[0].kind != DataTypeLayout::BITMAP) {
-      // Types without a top-level validity bitmap (e.g. unions) are not yet
-      // handled here.
-      return Status::OK();
-    }
-    const int64_t selected_count = SelectedCount(selection);
-    if (selected_count == out->length) {
-      return Status::OK();
-    }
-    uint8_t* out_bitmap = out->buffers[0].data;
-    DCHECK_NE(out_bitmap, nullptr);
+	  Status ApplySelectionMask(const SelectionSpan& selection, ArraySpan* out) {
+	    if (out->length == 0) {
+	      return Status::OK();
+	    }
+	    if (out->type->layout().buffers.empty() ||
+	        out->type->layout().buffers[0].kind != DataTypeLayout::BITMAP) {
+	      // Types without a top-level validity bitmap (e.g. unions) are not yet
+	      // handled here.
+	      return Status::OK();
+	    }
+	    const int64_t selected_count = SelectedCount(selection);
+	    const int64_t base = out->offset;
+	    const int64_t len = out->length;
 
-    const int64_t base = out->offset;
-    const int64_t len = out->length;
+	    if (selected_count == len) {
+	      // No rows are unselected in this span. Still, an OUTPUT_NOT_NULL kernel may rely on
+	      // the executor to ensure the preallocated validity is set to all-valid.
+	      if (kernel_->null_handling == NullHandling::OUTPUT_NOT_NULL) {
+	        if (uint8_t* out_bitmap = out->buffers[0].data) {
+	          bit_util::SetBitsTo(out_bitmap, base, len, true);
+	        }
+	        out->null_count = 0;
+	      }
+	      return Status::OK();
+	    }
 
-    if (kernel_->null_handling == NullHandling::OUTPUT_NOT_NULL) {
-      // The kernel promises all selected rows are valid; only the selection introduces
-      // nulls.
-      bit_util::SetBitsTo(out_bitmap, base, len, false);
-      VisitSelectionSpanInline(selection,
-                               [&](int64_t i) { bit_util::SetBit(out_bitmap, base + i); });
-      out->null_count = len - selected_count;
-      return Status::OK();
-    }
+	    uint8_t* out_bitmap = out->buffers[0].data;
+	    DCHECK_NE(out_bitmap, nullptr);
 
-    return std::visit(
-        overloaded{
+	    if (kernel_->null_handling == NullHandling::OUTPUT_NOT_NULL) {
+	      // The kernel promises all selected rows are valid; only the selection introduces
+	      // nulls.
+	      bit_util::SetBitsTo(out_bitmap, base, len, false);
+	      VisitSelectionSpanInline(selection,
+	                               [&](int64_t i) { bit_util::SetBit(out_bitmap, base + i); });
+	      out->null_count = len - selected_count;
+	      return Status::OK();
+	    }
+
+	    return std::visit(
+	        overloaded{
             [&](const ContiguousSpan& span) -> Status {
               if (span.start_offset > 0) {
                 bit_util::SetBitsTo(out_bitmap, base, span.start_offset, false);
@@ -1268,95 +1277,36 @@ class ScalarExecutor : public KernelExecutorImpl<ScalarKernel> {
               out->null_count = kUnknownNullCount;
               return Status::OK();
             }},
-        selection);
-  }
+	        selection);
+	  }
 
-  Status ApplySelectionMask(const SelectionSpan& selection, ArrayData* out) {
-    if (out->length == 0) {
-      return Status::OK();
-    }
-    if (out->type->layout().buffers.empty() ||
-        out->type->layout().buffers[0].kind != DataTypeLayout::BITMAP) {
-      return Status::OK();
-    }
-    if (out->buffers.empty()) {
-      return Status::OK();
-    }
-    if (out->buffers[0] == nullptr) {
-      // A missing validity bitmap implies "all valid". Materialize an all-valid bitmap so
-      // we can mask it with the selection.
-      const int64_t bitmap_length = out->offset + out->length;
-      ARROW_ASSIGN_OR_RAISE(out->buffers[0],
-                            AllocateEmptyBitmap(bitmap_length, exec_context()->memory_pool()));
-      bit_util::SetBitsTo(out->buffers[0]->mutable_data(), /*start_offset=*/0,
-                          bitmap_length, true);
-      out->null_count = 0;
-    }
-
-    const int64_t selected_count = SelectedCount(selection);
-    if (selected_count == out->length) {
-      return Status::OK();
-    }
-
-    uint8_t* out_bitmap = out->buffers[0]->mutable_data();
-    const int64_t base = out->offset;
-    const int64_t len = out->length;
-
-    if (kernel_->null_handling == NullHandling::OUTPUT_NOT_NULL) {
-      bit_util::SetBitsTo(out_bitmap, base, len, false);
-      VisitSelectionSpanInline(selection,
-                               [&](int64_t i) { bit_util::SetBit(out_bitmap, base + i); });
-      out->null_count = len - selected_count;
-      return Status::OK();
-    }
-
-    return std::visit(
-        overloaded{
-            [&](const ContiguousSpan& span) -> Status {
-              if (span.start_offset > 0) {
-                bit_util::SetBitsTo(out_bitmap, base, span.start_offset, false);
-              }
-              const int64_t end = span.start_offset + span.length;
-              if (end < len) {
-                bit_util::SetBitsTo(out_bitmap, base + end, len - end, false);
-              }
-              out->null_count = kUnknownNullCount;
-              return Status::OK();
-            },
-            [&](const FilteredSpan& span) -> Status {
-              DCHECK_NE(span.bitmap, nullptr);
-              if (span.start_offset > 0) {
-                bit_util::SetBitsTo(out_bitmap, base, span.start_offset, false);
-              }
-              const int64_t end = span.start_offset + span.length;
-              if (end < len) {
-                bit_util::SetBitsTo(out_bitmap, base + end, len - end, false);
-              }
-              BitmapAnd(out_bitmap, base + span.start_offset, span.bitmap, span.bitmap_offset,
-                        span.length, base + span.start_offset, out_bitmap);
-              out->null_count = kUnknownNullCount;
-              return Status::OK();
-            },
-            [&](const DiscreteSpan& span) -> Status {
-              int64_t cursor = 0;
-              for (int64_t i = 0; i < span.length; ++i) {
-                const int64_t idx = span[i];
-                DCHECK_GE(idx, 0);
-                DCHECK_LT(idx, len);
-                if (idx > cursor) {
-                  bit_util::SetBitsTo(out_bitmap, base + cursor, idx - cursor, false);
-                }
-                cursor = idx + 1;
-              }
-              if (cursor < len) {
-                bit_util::SetBitsTo(out_bitmap, base + cursor, len - cursor, false);
-              }
-              out->null_count = kUnknownNullCount;
-              return Status::OK();
-            }},
-        selection);
-  }
-};
+	  Status ApplySelectionMask(const SelectionSpan& selection, ArrayData* out) {
+	    if (out->length == 0) {
+	      return Status::OK();
+	    }
+	    if (out->type->layout().buffers.empty() ||
+	        out->type->layout().buffers[0].kind != DataTypeLayout::BITMAP) {
+	      return Status::OK();
+	    }
+	    if (out->buffers.empty()) {
+	      return Status::OK();
+	    }
+	    if (out->buffers[0] == nullptr) {
+	      // A missing validity bitmap implies "all valid". Materialize an all-valid bitmap so
+	      // we can mask it with the selection.
+	      const int64_t bitmap_length = out->offset + out->length;
+	      ARROW_ASSIGN_OR_RAISE(out->buffers[0],
+	                            AllocateEmptyBitmap(bitmap_length, exec_context()->memory_pool()));
+	      bit_util::SetBitsTo(out->buffers[0]->mutable_data(), /*start_offset=*/0,
+	                          bitmap_length, true);
+	      out->null_count = 0;
+	    }
+	    ArraySpan out_span(*out);
+	    RETURN_NOT_OK(ApplySelectionMask(selection, &out_span));
+	    out->null_count = out_span.null_count;
+	    return Status::OK();
+	  }
+	};
 
 namespace {
 

--- a/cpp/src/arrow/compute/exec.cc
+++ b/cpp/src/arrow/compute/exec.cc
@@ -1031,16 +1031,27 @@ class ScalarExecutor : public KernelExecutorImpl<ScalarKernel> {
       selection_ptr = &selection;
     }
     ExecResult output;
+    int64_t pending_empty_length = 0;
+
+    auto flush_pending_empty = [&]() -> Status {
+      if (pending_empty_length == 0) {
+        return Status::OK();
+      }
+      ARROW_ASSIGN_OR_RAISE(
+          std::shared_ptr<Array> all_null,
+          MakeArrayOfNull(output_type_.GetSharedPtr(), pending_empty_length,
+                          exec_context()->memory_pool()));
+      pending_empty_length = 0;
+      return EmitResult(all_null->data(), listener);
+    };
     while (span_iterator_.Next(&input, selection_ptr)) {
       if (selection_ptr != nullptr && SelectedCount(*selection_ptr) == 0) {
-        // No rows are selected in this span; output must be all-null.
-        ARROW_ASSIGN_OR_RAISE(
-            std::shared_ptr<Array> all_null,
-            MakeArrayOfNull(output_type_.GetSharedPtr(), input.length,
-                            exec_context()->memory_pool()));
-        RETURN_NOT_OK(EmitResult(all_null->data(), listener));
+        // No rows are selected in this span; skip kernel execution entirely.
+        // Coalesce consecutive empty spans to reduce output chunk overhead.
+        pending_empty_length += input.length;
         continue;
       }
+      RETURN_NOT_OK(flush_pending_empty());
       ARROW_ASSIGN_OR_RAISE(output.value, PrepareOutput(input.length));
       DCHECK(output.is_array_data());
 
@@ -1065,6 +1076,7 @@ class ScalarExecutor : public KernelExecutorImpl<ScalarKernel> {
       // Emit a result for each chunk
       RETURN_NOT_OK(EmitResult(output.array_data(), listener));
     }
+    RETURN_NOT_OK(flush_pending_empty());
     return Status::OK();
   }
 

--- a/cpp/src/arrow/compute/exec.cc
+++ b/cpp/src/arrow/compute/exec.cc
@@ -1660,83 +1660,99 @@ const CpuInfo* ExecContext::cpu_info() const { return CpuInfo::GetInstance(); }
 // ----------------------------------------------------------------------
 // SelectionVector
 
-SelectionVector::SelectionVector(std::shared_ptr<ArrayData> data)
-    : data_(std::move(data)) {
-  DCHECK_NE(data_, nullptr);
-  DCHECK_EQ(data_->type->id(), Type::UINT64);
-  indices_ = data_->GetValues<uint64_t>(1);
-}
+namespace {
 
-SelectionVector::SelectionVector(const Array& arr) : SelectionVector(arr.data()) {}
+class IndexSelectionVector final : public SelectionVector {
+ public:
+  explicit IndexSelectionVector(std::shared_ptr<ArrayData> data) : data_(std::move(data)) {
+    DCHECK_NE(data_, nullptr);
+    DCHECK_EQ(data_->type->id(), Type::UINT64);
+    indices_ = data_->GetValues<uint64_t>(1);
+  }
 
-int64_t SelectionVector::length() const { return data_->length; }
+  int64_t length() const override { return data_->length; }
 
-Status SelectionVector::Validate(int64_t values_length) const {
-  if (data_ == nullptr) {
-    return Status::Invalid("SelectionVector not initialized");
-  }
-  ARROW_CHECK_NE(indices_, nullptr);
-  if (data_->type->id() != Type::UINT64) {
-    return Status::Invalid("SelectionVector must be of type uint64");
-  }
-  if (data_->GetNullCount() != 0) {
-    return Status::Invalid("SelectionVector cannot contain nulls");
-  }
-  for (int64_t i = 1; i < length(); ++i) {
-    if (indices_[i - 1] >= indices_[i]) {
-      return Status::Invalid("SelectionVector indices must be strictly increasing");
+  Status Validate(int64_t values_length) const override {
+    if (data_ == nullptr) {
+      return Status::Invalid("SelectionVector not initialized");
     }
-  }
-  if (values_length >= 0) {
-    const uint64_t values_length_u64 = static_cast<uint64_t>(values_length);
-    for (int64_t i = 0; i < length(); ++i) {
-      if (indices_[i] >= values_length_u64) {
-        return Status::Invalid("SelectionVector index ", indices_[i],
-                               " >= values length ", values_length);
+    ARROW_CHECK_NE(indices_, nullptr);
+    if (data_->type->id() != Type::UINT64) {
+      return Status::Invalid("SelectionVector indices must be of type uint64");
+    }
+    if (data_->GetNullCount() != 0) {
+      return Status::Invalid("SelectionVector indices cannot contain nulls");
+    }
+    for (int64_t i = 1; i < length(); ++i) {
+      if (indices_[i - 1] >= indices_[i]) {
+        return Status::Invalid("SelectionVector indices must be strictly increasing");
       }
     }
-  }
-  return Status::OK();
-}
-
-Result<std::shared_ptr<ArrayData>> SelectionVector::ToIndicesArrayData(
-    MemoryPool* pool) const {
-  (void)pool;
-  return data_;
-}
-
-int64_t SelectionVector::GetSpanForChunk(uint64_t chunk_start, uint64_t chunk_end,
-                                        int64_t selection_position,
-                                        SelectionSpan* out) const {
-  DCHECK_NE(out, nullptr);
-  DCHECK_LE(chunk_start, chunk_end);
-
-  const uint64_t* indices_begin = indices_ + selection_position;
-  const uint64_t* indices_end = indices_ + length();
-  DCHECK_LE(indices_begin, indices_end);
-
-  const uint64_t* indices_limit = std::lower_bound(indices_begin, indices_end, chunk_end);
-  const int64_t num_indices = indices_limit - indices_begin;
-
-  if (num_indices > 0) {
-    const uint64_t first = indices_begin[0];
-    const uint64_t last = indices_begin[num_indices - 1];
-    DCHECK_GE(first, chunk_start);
-    DCHECK_LT(last, chunk_end);
-
-    // If the discrete indices form a contiguous run, represent them as such.
-    // Since SelectionVector::Validate enforces strict increasing order, checking
-    // (last - first == num_indices - 1) is sufficient.
-    if (last - first == static_cast<uint64_t>(num_indices - 1)) {
-      *out = ContiguousSpan{static_cast<int64_t>(first - chunk_start), num_indices};
-    } else {
-      *out = DiscreteSpan{indices_begin, num_indices, chunk_start};
+    if (values_length >= 0) {
+      const uint64_t values_length_u64 = static_cast<uint64_t>(values_length);
+      for (int64_t i = 0; i < length(); ++i) {
+        if (indices_[i] >= values_length_u64) {
+          return Status::Invalid("SelectionVector index ", indices_[i],
+                                 " >= values length ", values_length);
+        }
+      }
     }
-  } else {
-    *out = DiscreteSpan{indices_begin, /*length=*/0, chunk_start};
+    return Status::OK();
   }
 
-  return num_indices;
+  Result<std::shared_ptr<ArrayData>> ToIndicesArrayData(MemoryPool* pool) const override {
+    (void)pool;
+    return data_;
+  }
+
+  int64_t GetSpanForChunk(uint64_t chunk_start, uint64_t chunk_end,
+                          int64_t selection_position,
+                          SelectionSpan* out) const override {
+    DCHECK_NE(out, nullptr);
+    DCHECK_LE(chunk_start, chunk_end);
+
+    const uint64_t* indices_begin = indices_ + selection_position;
+    const uint64_t* indices_end = indices_ + length();
+    DCHECK_LE(indices_begin, indices_end);
+
+    const uint64_t* indices_limit = std::lower_bound(indices_begin, indices_end, chunk_end);
+    const int64_t num_indices = indices_limit - indices_begin;
+
+    if (num_indices > 0) {
+      const uint64_t first = indices_begin[0];
+      const uint64_t last = indices_begin[num_indices - 1];
+      DCHECK_GE(first, chunk_start);
+      DCHECK_LT(last, chunk_end);
+
+      // If the discrete indices form a contiguous run, represent them as such.
+      // Since Validate enforces strict increasing order, checking
+      // (last - first == num_indices - 1) is sufficient.
+      if (last - first == static_cast<uint64_t>(num_indices - 1)) {
+        *out = ContiguousSpan{static_cast<int64_t>(first - chunk_start), num_indices};
+      } else {
+        *out = DiscreteSpan{indices_begin, num_indices, chunk_start};
+      }
+    } else {
+      *out = DiscreteSpan{indices_begin, /*length=*/0, chunk_start};
+    }
+
+    return num_indices;
+  }
+
+ private:
+  std::shared_ptr<ArrayData> data_;
+  const uint64_t* indices_;
+};
+
+}  // namespace
+
+std::shared_ptr<SelectionVector> SelectionVector::MakeIndices(
+    std::shared_ptr<ArrayData> data) {
+  return std::make_shared<IndexSelectionVector>(std::move(data));
+}
+
+std::shared_ptr<SelectionVector> SelectionVector::MakeIndices(const Array& arr) {
+  return MakeIndices(arr.data());
 }
 
 Result<Datum> CallFunction(const std::string& func_name, const std::vector<Datum>& args,

--- a/cpp/src/arrow/compute/exec.cc
+++ b/cpp/src/arrow/compute/exec.cc
@@ -27,7 +27,6 @@
 
 #include "arrow/array/array_base.h"
 #include "arrow/array/array_primitive.h"
-#include "arrow/array/concatenate.h"
 #include "arrow/array/data.h"
 #include "arrow/array/util.h"
 #include "arrow/buffer.h"
@@ -883,56 +882,41 @@ class ScalarExecutor : public KernelExecutorImpl<ScalarKernel> {
       return ExecuteBatch(input, listener);
     }
 
-    ARROW_ASSIGN_OR_RAISE(auto values,
-                          batch.selection_vector->GatherValues(batch, exec_context()));
+    ARROW_ASSIGN_OR_RAISE(
+        std::shared_ptr<ArrayData> take_indices_data,
+        batch.selection_vector->ToIndicesArrayData(exec_context()->memory_pool()));
+    Datum take_indices = Datum(std::move(take_indices_data));
+
+    std::vector<Datum> values(batch.num_values());
+    for (int i = 0; i < batch.num_values(); ++i) {
+      if (batch[i].is_scalar()) {
+        // XXX: Skip gather for scalars since it is not currently supported by Take.
+        values[i] = batch[i];
+      } else {
+        ARROW_ASSIGN_OR_RAISE(
+            values[i],
+            Take(batch[i], take_indices, TakeOptions{/*boundcheck=*/false}, exec_context()));
+      }
+    }
     ARROW_ASSIGN_OR_RAISE(
         ExecBatch input,
         ExecBatch::Make(std::move(values), batch.selection_vector->length()));
 
     DatumAccumulator dense_listener;
     RETURN_NOT_OK(ExecuteBatch(input, &dense_listener));
-    std::vector<Datum> dense_outputs = dense_listener.values();
-    const bool dense_split_execution = dense_outputs.size() > 1;
-    Datum dense_result = WrapResults(input.values, dense_outputs);
+    Datum dense_result = WrapResults(input.values, dense_listener.values());
 
-    ARROW_ASSIGN_OR_RAISE(
-        Datum result,
-        batch.selection_vector->ScatterDenseResult(dense_result, batch.length,
-                                                   exec_context()));
-
-    // Preserve ScalarExecutor chunking semantics:
-    // - If any original inputs were chunked, WrapResults always returns a ChunkedArray.
-    // - If execution yielded multiple output chunks (typically because execution was
-    //   split and results were not fully preallocated), WrapResults returns a
-    //   ChunkedArray.
-    //
-    // The scatter step can return either an Array or a ChunkedArray depending on the
-    // selection backend; normalize to the expected output kind.
-    const bool want_chunked =
-        HaveChunkedArray(batch.values) || dense_split_execution;
-    if (want_chunked) {
-      if (result.is_array()) {
-        auto chunk = MakeArray(result.array());
-        result = Datum(std::make_shared<ChunkedArray>(std::move(chunk)));
-      } else if (result.is_chunked_array() && result.chunked_array()->num_chunks() != 1) {
-        ARROW_ASSIGN_OR_RAISE(auto combined,
-                              Concatenate(result.chunked_array()->chunks(),
-                                          exec_context()->memory_pool()));
-        result = Datum(std::make_shared<ChunkedArray>(std::move(combined)));
-      }
-    } else {
-      if (result.is_chunked_array()) {
-        const auto& carr = *result.chunked_array();
-        if (carr.num_chunks() == 1) {
-          result = Datum(carr.chunk(0)->data());
-        } else {
-          ARROW_ASSIGN_OR_RAISE(
-              auto combined,
-              Concatenate(carr.chunks(), exec_context()->memory_pool()));
-          result = Datum(std::move(combined));
-        }
-      }
+    // Scatter only accepts signed indices, while our SelectionVector is UInt64.
+    // Cast once here rather than constraining SelectionVector to signed indices.
+    Datum scatter_indices = take_indices;
+    if (scatter_indices.type()->id() == Type::UINT64) {
+      ARROW_ASSIGN_OR_RAISE(
+          scatter_indices,
+          Cast(scatter_indices, int64(), CastOptions::Safe(), exec_context()));
     }
+    ARROW_ASSIGN_OR_RAISE(auto result,
+                          Scatter(dense_result, scatter_indices,
+                                  ScatterOptions{/*max_index=*/batch.length - 1}));
     return listener->OnResult(std::move(result));
   }
 
@@ -1054,7 +1038,6 @@ class ScalarExecutor : public KernelExecutorImpl<ScalarKernel> {
   Status SetupPreallocation(int64_t total_length, const std::vector<Datum>& args) {
     output_num_buffers_ = static_cast<int>(output_type_.type->layout().buffers.size());
     auto out_type_id = output_type_.type->id();
-    data_preallocated_.clear();
     // Default to no validity pre-allocation for following cases:
     // - Output Array is NullArray
     // - kernel_->null_handling is COMPUTED_NO_PREALLOCATE or OUTPUT_NOT_NULL
@@ -1078,6 +1061,7 @@ class ScalarExecutor : public KernelExecutorImpl<ScalarKernel> {
       }
     }
     if (kernel_->mem_allocation == MemAllocation::PREALLOCATE) {
+      data_preallocated_.clear();
       ComputeDataPreallocate(*output_type_.type, &data_preallocated_);
     }
 
@@ -1477,651 +1461,83 @@ const CpuInfo* ExecContext::cpu_info() const { return CpuInfo::GetInstance(); }
 // ----------------------------------------------------------------------
 // SelectionVector
 
-namespace {
-
-Result<Datum> CoalesceChunkedToArray(Datum value, ExecContext* ctx) {
-  if (ctx == nullptr) {
-    ctx = default_exec_context();
-  }
-  if (!value.is_chunked_array()) {
-    return value;
-  }
-
-  const ChunkedArray& carr = *value.chunked_array();
-  if (carr.num_chunks() == 0) {
-    ARROW_ASSIGN_OR_RAISE(auto empty,
-                          MakeEmptyArray(value.type(), ctx->memory_pool()));
-    return Datum(std::move(empty));
-  }
-  if (carr.num_chunks() == 1) {
-    return Datum(carr.chunk(0)->data());
-  }
-  ARROW_ASSIGN_OR_RAISE(auto combined,
-                        Concatenate(carr.chunks(), ctx->memory_pool()));
-  return Datum(std::move(combined));
-}
-
-}  // namespace
-
-struct SelectionVector::Impl {
-  virtual ~Impl() = default;
-
-  virtual int64_t length() const = 0;
-  virtual Status Validate(int64_t values_length) const = 0;
-  virtual Result<std::shared_ptr<ArrayData>> ToIndicesArrayData(MemoryPool* pool) const = 0;
-  virtual Result<std::vector<Datum>> GatherValues(const ExecBatch& batch,
-                                                  ExecContext* ctx) const = 0;
-  virtual Result<Datum> ScatterDenseResult(const Datum& dense_result,
-                                          int64_t values_length,
-                                          ExecContext* ctx) const = 0;
-  virtual int64_t GetSpanForChunk(uint64_t chunk_start, uint64_t chunk_end,
-                                  int64_t selection_position,
-                                  SelectionSpan* out) const = 0;
-};
-
-struct SelectionVector::IndicesImpl final : public SelectionVector::Impl {
- public:
-  explicit IndicesImpl(std::shared_ptr<ArrayData> data)
-      : data_(std::move(data)) {
-    DCHECK_NE(data_, nullptr);
-    DCHECK_EQ(data_->type->id(), Type::UINT64);
-    indices_ = data_->GetValues<uint64_t>(1);
-    DCHECK(length() == 0 || indices_ != nullptr);
-  }
-
-  int64_t length() const override { return data_->length; }
-
-  Status Validate(int64_t values_length) const override {
-    if (data_ == nullptr) {
-      return Status::Invalid("SelectionVector not initialized");
-    }
-    if (length() > 0 && indices_ == nullptr) {
-      return Status::Invalid("SelectionVector indices buffer is missing");
-    }
-    if (data_->type->id() != Type::UINT64) {
-      return Status::Invalid("SelectionVector must be of type uint64");
-    }
-    if (data_->GetNullCount() != 0) {
-      return Status::Invalid("SelectionVector cannot contain nulls");
-    }
-    for (int64_t i = 1; i < length(); ++i) {
-      if (indices_[i - 1] >= indices_[i]) {
-        return Status::Invalid("SelectionVector indices must be strictly increasing");
-      }
-    }
-    if (values_length >= 0) {
-      const uint64_t values_length_u64 = static_cast<uint64_t>(values_length);
-      for (int64_t i = 0; i < length(); ++i) {
-        if (indices_[i] >= values_length_u64) {
-          return Status::Invalid("SelectionVector index ", indices_[i],
-                                 " >= values length ", values_length);
-        }
-      }
-    }
-    return Status::OK();
-  }
-
-  Result<std::shared_ptr<ArrayData>> ToIndicesArrayData(MemoryPool* pool) const override {
-    (void)pool;
-    return data_;
-  }
-
-  Result<std::vector<Datum>> GatherValues(const ExecBatch& batch,
-                                         ExecContext* ctx) const override {
-    if (ctx == nullptr) {
-      ctx = default_exec_context();
-    }
-
-    Datum take_indices(data_);
-    std::vector<Datum> values(batch.num_values());
-    for (int i = 0; i < batch.num_values(); ++i) {
-      if (batch[i].is_scalar()) {
-        // XXX: Skip gather for scalars since it is not currently supported by Take.
-        values[i] = batch[i];
-      } else {
-        ARROW_ASSIGN_OR_RAISE(
-            values[i],
-            Take(batch[i], take_indices, TakeOptions{/*boundscheck=*/false}, ctx));
-        // Gather should preserve kind (Array vs ChunkedArray) where possible. Since Take
-        // may return a ChunkedArray for array inputs depending on ExecContext settings,
-        // coalesce to a single Array when the input is an Array.
-        if (batch[i].is_array() && values[i].is_chunked_array()) {
-          ARROW_ASSIGN_OR_RAISE(values[i], CoalesceChunkedToArray(std::move(values[i]), ctx));
-        }
-      }
-    }
-    return values;
-  }
-
-  Result<Datum> ScatterDenseResult(const Datum& dense_result, int64_t values_length,
-                                  ExecContext* ctx) const override {
-    if (ctx == nullptr) {
-      ctx = default_exec_context();
-    }
-    if (values_length < 0) {
-      return Status::Invalid("values_length must be non-negative");
-    }
-
-    // Scatter only accepts signed indices, while our indices are UInt64.
-    Datum scatter_indices(data_);
-    if (scatter_indices.type()->id() == Type::UINT64) {
-      ARROW_ASSIGN_OR_RAISE(scatter_indices,
-                            Cast(scatter_indices, int64(), CastOptions::Safe(), ctx));
-    }
-
-    return Scatter(dense_result, scatter_indices,
-                   ScatterOptions{/*max_index=*/values_length - 1}, ctx);
-  }
-
-  int64_t GetSpanForChunk(uint64_t chunk_start, uint64_t chunk_end,
-                          int64_t selection_position,
-                          SelectionSpan* out) const override {
-    DCHECK_NE(out, nullptr);
-    DCHECK_LE(chunk_start, chunk_end);
-
-    if (length() == 0) {
-      *out = DiscreteSpan{/*indices=*/nullptr, /*length=*/0, chunk_start};
-      return 0;
-    }
-
-    const uint64_t* indices_begin = indices_ + selection_position;
-    const uint64_t* indices_end = indices_ + length();
-    DCHECK_LE(indices_begin, indices_end);
-
-    const uint64_t* indices_limit =
-        std::lower_bound(indices_begin, indices_end, chunk_end);
-    const int64_t num_indices = indices_limit - indices_begin;
-
-    if (num_indices > 0) {
-      const uint64_t first = indices_begin[0];
-      const uint64_t last = indices_begin[num_indices - 1];
-      DCHECK_GE(first, chunk_start);
-      DCHECK_LT(last, chunk_end);
-
-      // If the discrete indices form a contiguous run, represent them as such.
-      // Since Validate enforces strict increasing order, checking (last - first ==
-      // num_indices - 1) is sufficient.
-      if (last - first == static_cast<uint64_t>(num_indices - 1)) {
-        *out = ContiguousSpan{static_cast<int64_t>(first - chunk_start), num_indices};
-      } else {
-        *out = DiscreteSpan{indices_begin, num_indices, chunk_start};
-      }
-    } else {
-      *out = DiscreteSpan{indices_begin, /*length=*/0, chunk_start};
-    }
-
-    return num_indices;
-  }
-
- private:
-  std::shared_ptr<ArrayData> data_;
-  const uint64_t* indices_ = NULLPTR;
-};
-
-struct SelectionVector::MaskImpl final : public SelectionVector::Impl {
- public:
-  MaskImpl(std::shared_ptr<ArrayData> mask, int64_t selection_length)
-      : mask_(std::move(mask)), selection_length_(selection_length) {
-    DCHECK_NE(mask_, nullptr);
-    DCHECK_EQ(mask_->type->id(), Type::BOOL);
-    DCHECK_GE(selection_length_, 0);
-    // Boolean values are bit-packed, so always use absolute_offset=0 and apply
-    // any bit offset manually.
-    bitmap_ = mask_->GetValues<uint8_t>(1, /*absolute_offset=*/0);
-    DCHECK(mask_->length == 0 || bitmap_ != nullptr);
-  }
-
-  int64_t length() const override { return selection_length_; }
-
-  Status Validate(int64_t values_length) const override {
-    if (mask_ == nullptr) {
-      return Status::Invalid("SelectionVector not initialized");
-    }
-    if (mask_->type->id() != Type::BOOL) {
-      return Status::Invalid("SelectionVector mask must be of type bool");
-    }
-    if (values_length >= 0 && mask_->length != values_length) {
-      return Status::Invalid("SelectionVector mask length ", mask_->length,
-                             " != values length ", values_length);
-    }
-    if (mask_->GetNullCount() != 0) {
-      return Status::Invalid("SelectionVector mask cannot contain nulls");
-    }
-    const int64_t computed =
-        ::arrow::internal::CountSetBits(bitmap_, mask_->offset, mask_->length);
-    if (computed != selection_length_) {
-      return Status::Invalid("SelectionVector mask selection length mismatch");
-    }
-    return Status::OK();
-  }
-
-  Result<std::shared_ptr<ArrayData>> ToIndicesArrayData(MemoryPool* pool) const override {
-    if (pool == nullptr) {
-      pool = default_memory_pool();
-    }
-    ARROW_ASSIGN_OR_RAISE(auto indices_buf,
-                          AllocateBuffer(selection_length_ * sizeof(uint64_t), pool));
-    auto out = reinterpret_cast<uint64_t*>(indices_buf->mutable_data());
-    int64_t out_pos = 0;
-    for (int64_t i = 0; i < mask_->length; ++i) {
-      if (bit_util::GetBit(bitmap_, mask_->offset + i)) {
-        out[out_pos++] = static_cast<uint64_t>(i);
-      }
-    }
-    DCHECK_EQ(out_pos, selection_length_);
-    return ArrayData::Make(uint64(), selection_length_, {nullptr, std::move(indices_buf)},
-                           /*null_count=*/0);
-  }
-
-  Result<std::vector<Datum>> GatherValues(const ExecBatch& batch,
-                                         ExecContext* ctx) const override {
-    if (ctx == nullptr) {
-      ctx = default_exec_context();
-    }
-    Datum mask(mask_);
-    const FilterOptions opts(FilterOptions::DROP);
-
-    std::vector<Datum> values(batch.num_values());
-    for (int i = 0; i < batch.num_values(); ++i) {
-      if (batch[i].is_scalar()) {
-        values[i] = batch[i];
-      } else {
-        ARROW_ASSIGN_OR_RAISE(values[i], Filter(batch[i], mask, opts, ctx));
-        // Gather should preserve kind (Array vs ChunkedArray) where possible. Since
-        // Filter may return a ChunkedArray for array inputs depending on ExecContext
-        // settings, coalesce to a single Array when the input is an Array.
-        if (batch[i].is_array() && values[i].is_chunked_array()) {
-          ARROW_ASSIGN_OR_RAISE(values[i], CoalesceChunkedToArray(std::move(values[i]), ctx));
-        }
-      }
-    }
-    return values;
-  }
-
-  Result<Datum> ScatterDenseResult(const Datum& dense_result, int64_t values_length,
-                                  ExecContext* ctx) const override {
-    if (ctx == nullptr) {
-      ctx = default_exec_context();
-    }
-    if (values_length < 0) {
-      return Status::Invalid("values_length must be non-negative");
-    }
-
-    // Try a mask-based scatter, which can avoid materializing indices.
-    ARROW_ASSIGN_OR_RAISE(
-        auto base_nulls,
-        MakeArrayOfNull(dense_result.type(), values_length, ctx->memory_pool()));
-    auto maybe_mask_scatter =
-        ReplaceWithMask(Datum(std::move(base_nulls)), Datum(mask_), dense_result, ctx);
-    if (maybe_mask_scatter.ok()) {
-      return maybe_mask_scatter;
-    }
-
-    // Fall back to an indices-based scatter for unsupported types.
-    ARROW_ASSIGN_OR_RAISE(auto indices_data, ToIndicesArrayData(ctx->memory_pool()));
-    Datum scatter_indices(std::move(indices_data));
-    ARROW_ASSIGN_OR_RAISE(scatter_indices,
-                          Cast(scatter_indices, int64(), CastOptions::Safe(), ctx));
-    return Scatter(dense_result, scatter_indices,
-                   ScatterOptions{/*max_index=*/values_length - 1}, ctx);
-  }
-
-  int64_t GetSpanForChunk(uint64_t chunk_start, uint64_t chunk_end,
-                          int64_t selection_position,
-                          SelectionSpan* out) const override {
-    DCHECK_NE(out, nullptr);
-    DCHECK_LE(chunk_start, chunk_end);
-    DCHECK_GE(selection_position, 0);
-    DCHECK_LE(selection_position, selection_length_);
-
-    const uint64_t values_length = static_cast<uint64_t>(mask_->length);
-    const uint64_t clamped_start = std::min(chunk_start, values_length);
-    const uint64_t clamped_end = std::min(chunk_end, values_length);
-    DCHECK_LE(clamped_start, clamped_end);
-    const int64_t chunk_length = static_cast<int64_t>(clamped_end - clamped_start);
-    *out = FilteredSpan{/*start_offset=*/0,
-                        /*length=*/chunk_length,
-                        /*bitmap=*/bitmap_,
-                        /*bitmap_offset=*/static_cast<int64_t>(clamped_start) +
-                            mask_->offset};
-
-    return ::arrow::internal::CountSetBits(
-        bitmap_, static_cast<int64_t>(clamped_start) + mask_->offset, chunk_length);
-  }
-
- private:
-  std::shared_ptr<ArrayData> mask_;
-  int64_t selection_length_ = 0;
-  const uint8_t* bitmap_ = NULLPTR;
-};
-
-struct SelectionVector::RangesImpl final : public SelectionVector::Impl {
- public:
-  RangesImpl(std::vector<SelectionRange> ranges, int64_t values_length,
-             std::shared_ptr<ArrayData> mask, int64_t selection_length)
-      : ranges_(std::move(ranges)),
-        values_length_(values_length),
-        mask_(std::move(mask)),
-        selection_length_(selection_length) {
-    DCHECK_NE(mask_, nullptr);
-    DCHECK_EQ(mask_->type->id(), Type::BOOL);
-    // Boolean values are bit-packed, so always use absolute_offset=0 and apply
-    // any bit offset manually.
-    bitmap_ = mask_->GetValues<uint8_t>(1, /*absolute_offset=*/0);
-    DCHECK(mask_->length == 0 || bitmap_ != nullptr);
-  }
-
-  int64_t length() const override { return selection_length_; }
-
-  Status Validate(int64_t values_length) const override {
-    if (values_length >= 0 && values_length != values_length_) {
-      return Status::Invalid("SelectionVector values_length mismatch");
-    }
-    if (mask_->GetNullCount() != 0) {
-      return Status::Invalid("SelectionVector mask cannot contain nulls");
-    }
-    if (mask_->length != values_length_) {
-      return Status::Invalid("SelectionVector mask length mismatch");
-    }
-    uint64_t prev_end = 0;
-    bool first = true;
-    int64_t total = 0;
-    for (const auto& r : ranges_) {
-      if (r.length == 0) {
-        continue;
-      }
-      if (r.start + r.length < r.start) {
-        return Status::Invalid("SelectionVector range overflow");
-      }
-      if (!first && r.start < prev_end) {
-        return Status::Invalid("SelectionVector ranges must be sorted and non-overlapping");
-      }
-      first = false;
-      prev_end = r.start + r.length;
-      if (static_cast<int64_t>(prev_end) > values_length_) {
-        return Status::Invalid("SelectionVector range end out of bounds");
-      }
-      total += static_cast<int64_t>(r.length);
-    }
-    if (total != selection_length_) {
-      return Status::Invalid("SelectionVector ranges selection length mismatch");
-    }
-    const int64_t computed =
-        ::arrow::internal::CountSetBits(bitmap_, mask_->offset, mask_->length);
-    if (computed != selection_length_) {
-      return Status::Invalid("SelectionVector mask selection length mismatch");
-    }
-    return Status::OK();
-  }
-
-  Result<std::shared_ptr<ArrayData>> ToIndicesArrayData(MemoryPool* pool) const override {
-    if (pool == nullptr) {
-      pool = default_memory_pool();
-    }
-    ARROW_ASSIGN_OR_RAISE(auto indices_buf,
-                          AllocateBuffer(selection_length_ * sizeof(uint64_t), pool));
-    auto out = reinterpret_cast<uint64_t*>(indices_buf->mutable_data());
-    int64_t out_pos = 0;
-    for (const auto& r : ranges_) {
-      for (uint64_t i = 0; i < r.length; ++i) {
-        out[out_pos++] = r.start + i;
-      }
-    }
-    DCHECK_EQ(out_pos, selection_length_);
-    return ArrayData::Make(uint64(), selection_length_, {nullptr, std::move(indices_buf)},
-                           /*null_count=*/0);
-  }
-
-  Result<std::vector<Datum>> GatherValues(const ExecBatch& batch,
-                                         ExecContext* ctx) const override {
-    if (ctx == nullptr) {
-      ctx = default_exec_context();
-    }
-
-    std::vector<Datum> values(batch.num_values());
-    for (int i = 0; i < batch.num_values(); ++i) {
-      if (batch[i].is_scalar()) {
-        values[i] = batch[i];
-        continue;
-      }
-
-      if (ranges_.empty()) {
-        // Preserve the value kind (array vs chunked array) where possible.
-        if (batch[i].is_array()) {
-          values[i] = batch[i].array()->Slice(0, 0);
-        } else {
-          values[i] = batch[i].chunked_array()->Slice(0, 0);
-        }
-        continue;
-      }
-
-      if (ranges_.size() == 1) {
-        const auto& r = ranges_[0];
-        const int64_t start = static_cast<int64_t>(r.start);
-        const int64_t len = static_cast<int64_t>(r.length);
-        if (batch[i].is_array()) {
-          values[i] = batch[i].array()->Slice(start, len);
-        } else {
-          values[i] = batch[i].chunked_array()->Slice(start, len);
-        }
-        continue;
-      }
-
-      // Multiple ranges: build a ChunkedArray of slices (zero-copy where possible).
-      if (batch[i].is_array()) {
-        const auto& arr = *batch[i].array();
-        ArrayVector slices;
-        slices.reserve(ranges_.size());
-        for (const auto& r : ranges_) {
-          slices.push_back(MakeArray(arr.Slice(static_cast<int64_t>(r.start),
-                                               static_cast<int64_t>(r.length))));
-        }
-        // Preserve array kind for array inputs, even with multiple ranges.
-        ARROW_ASSIGN_OR_RAISE(auto concatenated,
-                              Concatenate(slices, ctx->memory_pool()));
-        values[i] = Datum(std::move(concatenated));
-      } else {
-        ArrayVector chunks;
-        chunks.reserve(ranges_.size());
-        const auto& carr = *batch[i].chunked_array();
-        for (const auto& r : ranges_) {
-          auto sliced = carr.Slice(static_cast<int64_t>(r.start),
-                                   static_cast<int64_t>(r.length));
-          for (const auto& chunk : sliced->chunks()) {
-            chunks.push_back(chunk);
-          }
-        }
-        values[i] =
-            Datum(std::make_shared<ChunkedArray>(std::move(chunks), batch[i].type()));
-      }
-    }
-
-    return values;
-  }
-
-  Result<Datum> ScatterDenseResult(const Datum& dense_result, int64_t values_length,
-                                  ExecContext* ctx) const override {
-    if (ctx == nullptr) {
-      ctx = default_exec_context();
-    }
-    if (values_length != values_length_) {
-      return Status::Invalid("SelectionVector ranges scatter values_length mismatch");
-    }
-    if (values_length < 0) {
-      return Status::Invalid("values_length must be non-negative");
-    }
-
-    // Prefer a mask-based scatter, which produces a single array and can avoid
-    // materializing indices.
-    ARROW_ASSIGN_OR_RAISE(
-        auto base_nulls,
-        MakeArrayOfNull(dense_result.type(), values_length_, ctx->memory_pool()));
-    auto maybe_mask_scatter =
-        ReplaceWithMask(Datum(std::move(base_nulls)), Datum(mask_), dense_result, ctx);
-    if (maybe_mask_scatter.ok()) {
-      return maybe_mask_scatter;
-    }
-
-    // Fall back to an indices-based scatter for unsupported types.
-    ARROW_ASSIGN_OR_RAISE(auto indices_data, ToIndicesArrayData(ctx->memory_pool()));
-    Datum scatter_indices(std::move(indices_data));
-    ARROW_ASSIGN_OR_RAISE(scatter_indices,
-                          Cast(scatter_indices, int64(), CastOptions::Safe(), ctx));
-    return Scatter(dense_result, scatter_indices,
-                   ScatterOptions{/*max_index=*/values_length_ - 1}, ctx);
-  }
-
-  int64_t GetSpanForChunk(uint64_t chunk_start, uint64_t chunk_end,
-                          int64_t selection_position,
-                          SelectionSpan* out) const override {
-    DCHECK_NE(out, nullptr);
-    DCHECK_LE(chunk_start, chunk_end);
-    DCHECK_GE(selection_position, 0);
-    DCHECK_LE(selection_position, selection_length_);
-
-    const uint64_t values_length = static_cast<uint64_t>(values_length_);
-    const uint64_t clamped_start = std::min(chunk_start, values_length);
-    const uint64_t clamped_end = std::min(chunk_end, values_length);
-    DCHECK_LE(clamped_start, clamped_end);
-    const int64_t chunk_length = static_cast<int64_t>(clamped_end - clamped_start);
-    *out = FilteredSpan{/*start_offset=*/0,
-                        /*length=*/chunk_length,
-                        /*bitmap=*/bitmap_,
-                        /*bitmap_offset=*/static_cast<int64_t>(clamped_start) +
-                            mask_->offset};
-
-    return ::arrow::internal::CountSetBits(
-        bitmap_, static_cast<int64_t>(clamped_start) + mask_->offset, chunk_length);
-  }
-
- private:
-  std::vector<SelectionRange> ranges_;
-  int64_t values_length_ = 0;
-  std::shared_ptr<ArrayData> mask_;
-  int64_t selection_length_ = 0;
-  const uint8_t* bitmap_ = NULLPTR;
-};
-
 SelectionVector::SelectionVector(std::shared_ptr<ArrayData> data)
-    : impl_(std::make_shared<IndicesImpl>(std::move(data))) {}
-
-SelectionVector::SelectionVector(std::shared_ptr<Impl> impl) : impl_(std::move(impl)) {}
+    : data_(std::move(data)) {
+  DCHECK_NE(data_, nullptr);
+  DCHECK_EQ(data_->type->id(), Type::UINT64);
+  indices_ = data_->GetValues<uint64_t>(1);
+}
 
 SelectionVector::SelectionVector(const Array& arr) : SelectionVector(arr.data()) {}
 
-Result<std::shared_ptr<SelectionVector>> SelectionVector::FromMask(const Array& mask,
-                                                                   MemoryPool* pool) {
-  if (pool == nullptr) {
-    pool = default_memory_pool();
-  }
-  if (mask.type_id() != Type::BOOL) {
-    return Status::TypeError("SelectionVector mask must be of type bool");
-  }
-
-  auto data = mask.data();
-  DCHECK_NE(data, nullptr);
-
-  const int64_t length = data->length;
-  const int64_t offset = data->offset;
-  // Boolean buffers are bit-packed, so always use absolute_offset=0 and apply
-  // the bit offset manually.
-  const uint8_t* values = data->GetValues<uint8_t>(1, /*absolute_offset=*/0);
-  const uint8_t* validity = data->GetValues<uint8_t>(0, /*absolute_offset=*/0);
-
-  std::shared_ptr<ArrayData> normalized;
-  if (offset == 0 && data->GetNullCount() == 0) {
-    normalized = data;
-  } else {
-    std::shared_ptr<Buffer> bitmap;
-    if (data->GetNullCount() == 0) {
-      ARROW_ASSIGN_OR_RAISE(bitmap, AllocateEmptyBitmap(length, pool));
-      CopyBitmap(values, offset, length, bitmap->mutable_data(),
-                           /*dest_offset=*/0);
-    } else {
-      // Treat nulls as false by intersecting validity and values bitmaps.
-      DCHECK_NE(validity, nullptr);
-      ARROW_ASSIGN_OR_RAISE(bitmap, BitmapAnd(pool, values, offset, validity, offset,
-                                              length, /*out_offset=*/0));
-    }
-    normalized = ArrayData::Make(boolean(), length, {nullptr, std::move(bitmap)},
-                                 /*null_count=*/0);
-  }
-
-  const uint8_t* bitmap = normalized->GetValues<uint8_t>(1, /*absolute_offset=*/0);
-  const int64_t selection_length = ::arrow::internal::CountSetBits(
-      bitmap, normalized->offset, normalized->length);
-  return std::shared_ptr<SelectionVector>(new SelectionVector(
-      std::make_shared<MaskImpl>(std::move(normalized), selection_length)));
-}
-
-Result<std::shared_ptr<SelectionVector>> SelectionVector::FromRanges(
-    std::vector<SelectionRange> ranges, int64_t values_length, MemoryPool* pool) {
-  if (pool == nullptr) {
-    pool = default_memory_pool();
-  }
-  if (values_length < 0) {
-    return Status::Invalid("values_length must be non-negative");
-  }
-
-  uint64_t prev_end = 0;
-  bool first = true;
-  int64_t selection_length = 0;
-  for (auto& r : ranges) {
-    if (r.length == 0) {
-      continue;
-    }
-    if (r.start + r.length < r.start) {
-      return Status::Invalid("SelectionVector range overflow");
-    }
-    if (!first && r.start < prev_end) {
-      return Status::Invalid("SelectionVector ranges must be sorted and non-overlapping");
-    }
-    first = false;
-    prev_end = r.start + r.length;
-    if (static_cast<int64_t>(prev_end) > values_length) {
-      return Status::Invalid("SelectionVector range end out of bounds");
-    }
-    selection_length += static_cast<int64_t>(r.length);
-  }
-
-  ARROW_ASSIGN_OR_RAISE(auto bitmap, AllocateEmptyBitmap(values_length, pool));
-  for (const auto& r : ranges) {
-    bit_util::SetBitsTo(bitmap->mutable_data(), static_cast<int64_t>(r.start),
-                        static_cast<int64_t>(r.length), true);
-  }
-  auto mask = ArrayData::Make(boolean(), values_length, {nullptr, std::move(bitmap)},
-                              /*null_count=*/0);
-
-  return std::shared_ptr<SelectionVector>(
-      new SelectionVector(std::make_shared<RangesImpl>(
-          std::move(ranges), values_length, std::move(mask), selection_length)));
-}
-
-int64_t SelectionVector::length() const { return impl_->length(); }
+int64_t SelectionVector::length() const { return data_->length; }
 
 Status SelectionVector::Validate(int64_t values_length) const {
-  return impl_->Validate(values_length);
+  if (data_ == nullptr) {
+    return Status::Invalid("SelectionVector not initialized");
+  }
+  ARROW_CHECK_NE(indices_, nullptr);
+  if (data_->type->id() != Type::UINT64) {
+    return Status::Invalid("SelectionVector must be of type uint64");
+  }
+  if (data_->GetNullCount() != 0) {
+    return Status::Invalid("SelectionVector cannot contain nulls");
+  }
+  for (int64_t i = 1; i < length(); ++i) {
+    if (indices_[i - 1] >= indices_[i]) {
+      return Status::Invalid("SelectionVector indices must be strictly increasing");
+    }
+  }
+  if (values_length >= 0) {
+    const uint64_t values_length_u64 = static_cast<uint64_t>(values_length);
+    for (int64_t i = 0; i < length(); ++i) {
+      if (indices_[i] >= values_length_u64) {
+        return Status::Invalid("SelectionVector index ", indices_[i],
+                               " >= values length ", values_length);
+      }
+    }
+  }
+  return Status::OK();
 }
 
-Result<std::shared_ptr<ArrayData>> SelectionVector::ToIndicesArrayData(MemoryPool* pool) const {
-  return impl_->ToIndicesArrayData(pool);
-}
-
-Result<std::vector<Datum>> SelectionVector::GatherValues(const ExecBatch& batch,
-                                                         ExecContext* ctx) const {
-  return impl_->GatherValues(batch, ctx);
-}
-
-Result<Datum> SelectionVector::ScatterDenseResult(const Datum& dense_result,
-                                                  int64_t values_length,
-                                                  ExecContext* ctx) const {
-  return impl_->ScatterDenseResult(dense_result, values_length, ctx);
+Result<std::shared_ptr<ArrayData>> SelectionVector::ToIndicesArrayData(
+    MemoryPool* pool) const {
+  (void)pool;
+  return data_;
 }
 
 int64_t SelectionVector::GetSpanForChunk(uint64_t chunk_start, uint64_t chunk_end,
                                         int64_t selection_position,
                                         SelectionSpan* out) const {
-  return impl_->GetSpanForChunk(chunk_start, chunk_end, selection_position, out);
+  DCHECK_NE(out, nullptr);
+  DCHECK_LE(chunk_start, chunk_end);
+
+  const uint64_t* indices_begin = indices_ + selection_position;
+  const uint64_t* indices_end = indices_ + length();
+  DCHECK_LE(indices_begin, indices_end);
+
+  const uint64_t* indices_limit = std::lower_bound(indices_begin, indices_end, chunk_end);
+  const int64_t num_indices = indices_limit - indices_begin;
+
+  if (num_indices > 0) {
+    const uint64_t first = indices_begin[0];
+    const uint64_t last = indices_begin[num_indices - 1];
+    DCHECK_GE(first, chunk_start);
+    DCHECK_LT(last, chunk_end);
+
+    // If the discrete indices form a contiguous run, represent them as such.
+    // Since SelectionVector::Validate enforces strict increasing order, checking
+    // (last - first == num_indices - 1) is sufficient.
+    if (last - first == static_cast<uint64_t>(num_indices - 1)) {
+      *out = ContiguousSpan{static_cast<int64_t>(first - chunk_start), num_indices};
+    } else {
+      *out = DiscreteSpan{indices_begin, num_indices, chunk_start};
+    }
+  } else {
+    *out = DiscreteSpan{indices_begin, /*length=*/0, chunk_start};
+  }
+
+  return num_indices;
 }
 
 Result<Datum> CallFunction(const std::string& func_name, const std::vector<Datum>& args,

--- a/cpp/src/arrow/compute/exec.cc
+++ b/cpp/src/arrow/compute/exec.cc
@@ -451,13 +451,6 @@ bool ExecSpanIterator::Next(ExecSpan* span, SelectionSpan* selection_span) {
       PromoteExecSpanScalars(span);
     }
 
-    if (!have_all_scalars_ || promote_if_all_scalars_) {
-      if (selection_vector_) {
-        DCHECK_NE(selection_span, nullptr);
-        *selection_span = DiscreteSpan(selection_vector_->indices());
-      }
-    }
-
     initialized_ = true;
   } else if (position_ == length_) {
     // We've emitted at least one span and we're at the end so we are done
@@ -484,15 +477,36 @@ bool ExecSpanIterator::Next(ExecSpan* span, SelectionSpan* selection_span) {
   // Then the selection span
   if (selection_vector_) {
     DCHECK_NE(selection_span, nullptr);
-    auto indices_begin = selection_vector_->indices() + selection_position_;
-    auto indices_end = selection_vector_->indices() + selection_vector_->length();
+    const uint64_t chunk_start = static_cast<uint64_t>(position_);
+    const uint64_t chunk_end =
+        static_cast<uint64_t>(position_) + static_cast<uint64_t>(iteration_size);
+
+    const uint64_t* indices_begin = selection_vector_->indices() + selection_position_;
+    const uint64_t* indices_end = selection_vector_->indices() + selection_vector_->length();
     DCHECK_LE(indices_begin, indices_end);
-    auto indices_limit = std::lower_bound(
-        indices_begin, indices_end, static_cast<uint64_t>(position_ + iteration_size));
-    int64_t num_indices = indices_limit - indices_begin;
-    auto* discrete = std::get_if<DiscreteSpan>(selection_span);
-    DCHECK_NE(discrete, nullptr);
-    discrete->SetSlice(selection_position_, num_indices, static_cast<uint64_t>(position_));
+
+    const uint64_t* indices_limit = std::lower_bound(indices_begin, indices_end, chunk_end);
+    const int64_t num_indices = indices_limit - indices_begin;
+
+    if (num_indices > 0) {
+      const uint64_t first = indices_begin[0];
+      const uint64_t last = indices_begin[num_indices - 1];
+      DCHECK_GE(first, chunk_start);
+      DCHECK_LT(last, chunk_end);
+
+      // If the discrete indices form a contiguous run, represent them as such.
+      // Since SelectionVector::Validate enforces strict increasing order, checking
+      // (last - first == num_indices - 1) is sufficient.
+      if (last - first == static_cast<uint64_t>(num_indices - 1)) {
+        *selection_span =
+            ContiguousSpan{static_cast<int64_t>(first - chunk_start), num_indices};
+      } else {
+        *selection_span = DiscreteSpan{indices_begin, num_indices, chunk_start};
+      }
+    } else {
+      *selection_span = DiscreteSpan{indices_begin, /*length=*/0, chunk_start};
+    }
+
     selection_position_ += num_indices;
   }
 
@@ -1489,8 +1503,8 @@ Status SelectionVector::Validate(int64_t values_length) const {
     return Status::Invalid("SelectionVector cannot contain nulls");
   }
   for (int64_t i = 1; i < length(); ++i) {
-    if (indices_[i - 1] > indices_[i]) {
-      return Status::Invalid("SelectionVector indices must be sorted");
+    if (indices_[i - 1] >= indices_[i]) {
+      return Status::Invalid("SelectionVector indices must be strictly increasing");
     }
   }
   if (values_length >= 0) {
@@ -1503,14 +1517,6 @@ Status SelectionVector::Validate(int64_t values_length) const {
     }
   }
   return Status::OK();
-}
-
-void SelectionVectorSpan::SetSlice(int64_t offset, int64_t length,
-                                   uint64_t index_back_shift) {
-  DCHECK_NE(indices_, nullptr);
-  offset_ = offset;
-  length_ = length;
-  index_back_shift_ = index_back_shift;
 }
 
 Result<Datum> CallFunction(const std::string& func_name, const std::vector<Datum>& args,

--- a/cpp/src/arrow/compute/exec.cc
+++ b/cpp/src/arrow/compute/exec.cc
@@ -922,21 +922,8 @@ class ScalarExecutor : public KernelExecutorImpl<ScalarKernel> {
     }
 
     ARROW_ASSIGN_OR_RAISE(
-        std::shared_ptr<ArrayData> take_indices_data,
-        batch.selection_vector->ToIndicesArrayData(exec_context()->memory_pool()));
-    Datum take_indices = Datum(std::move(take_indices_data));
-
-    std::vector<Datum> values(batch.num_values());
-    for (int i = 0; i < batch.num_values(); ++i) {
-      if (batch[i].is_scalar()) {
-        // XXX: Skip gather for scalars since it is not currently supported by Take.
-        values[i] = batch[i];
-      } else {
-        ARROW_ASSIGN_OR_RAISE(
-            values[i],
-            Take(batch[i], take_indices, TakeOptions{/*boundcheck=*/false}, exec_context()));
-      }
-    }
+        std::vector<Datum> values,
+        batch.selection_vector->MakeDenseValues(batch.values, exec_context()));
     ARROW_ASSIGN_OR_RAISE(
         ExecBatch input,
         ExecBatch::Make(std::move(values), batch.selection_vector->length()));
@@ -945,15 +932,10 @@ class ScalarExecutor : public KernelExecutorImpl<ScalarKernel> {
     RETURN_NOT_OK(ExecuteBatch(input, &dense_listener));
     Datum dense_result = WrapResults(input.values, dense_listener.values());
 
-    Datum scatter_indices = take_indices;
-    if (scatter_indices.type()->id() == Type::UINT64) {
-      ARROW_ASSIGN_OR_RAISE(
-          scatter_indices,
-          Cast(scatter_indices, int64(), CastOptions::Safe(), exec_context()));
-    }
-    ARROW_ASSIGN_OR_RAISE(auto result,
-                          Scatter(dense_result, scatter_indices,
-                                  ScatterOptions{/*max_index=*/batch.length - 1}));
+    ARROW_ASSIGN_OR_RAISE(
+        auto result,
+        batch.selection_vector->ScatterDenseResult(dense_result, batch.length,
+                                                   exec_context()));
     return listener->OnResult(std::move(result));
   }
 
@@ -1705,6 +1687,34 @@ class IndexSelectionVector final : public SelectionVector {
   Result<std::shared_ptr<ArrayData>> ToIndicesArrayData(MemoryPool* pool) const override {
     (void)pool;
     return data_;
+  }
+
+  Result<std::vector<Datum>> MakeDenseValues(const std::vector<Datum>& values,
+                                             ExecContext* ctx) const override {
+    ARROW_ASSIGN_OR_RAISE(std::shared_ptr<ArrayData> indices_data,
+                          ToIndicesArrayData(ctx->memory_pool()));
+    Datum indices(std::move(indices_data));
+
+    std::vector<Datum> dense_values(values.size());
+    for (size_t i = 0; i < values.size(); ++i) {
+      if (values[i].is_scalar()) {
+        // XXX: Skip gather for scalars since it is not currently supported by Take.
+        dense_values[i] = values[i];
+      } else {
+        ARROW_ASSIGN_OR_RAISE(
+            dense_values[i],
+            Take(values[i], indices, TakeOptions{/*boundcheck=*/false}, ctx));
+      }
+    }
+    return dense_values;
+  }
+
+  Result<Datum> ScatterDenseResult(const Datum& dense_result, int64_t output_length,
+                                   ExecContext* ctx) const override {
+    ARROW_ASSIGN_OR_RAISE(std::shared_ptr<ArrayData> indices_data,
+                          ToIndicesArrayData(ctx->memory_pool()));
+    Datum indices(std::move(indices_data));
+    return Scatter(dense_result, indices, ScatterOptions{/*max_index=*/output_length - 1});
   }
 
   int64_t GetSpanForChunk(uint64_t chunk_start, uint64_t chunk_end,

--- a/cpp/src/arrow/compute/exec.cc
+++ b/cpp/src/arrow/compute/exec.cc
@@ -313,14 +313,6 @@ void ComputeDataPreallocate(const DataType& type,
 
 namespace detail {
 
-// Lambda helper & CTAD (C++17)
-template <class... Ts>
-struct overloaded : Ts... {
-  using Ts::operator()...;
-};
-template <class... Ts>
-overloaded(Ts...)->overloaded<Ts...>;
-
 // ----------------------------------------------------------------------
 // ExecSpanIterator
 
@@ -837,6 +829,56 @@ bool IsEmptySelection(const SelectionSpan* selection) {
   return selection != nullptr && SelectedCount(*selection) == 0;
 }
 
+Status ClearUnselectedValidity(const ContiguousSpan& span, int64_t base, int64_t len,
+                               uint8_t* out_bitmap) {
+  if (span.start_offset > 0) {
+    bit_util::SetBitsTo(out_bitmap, base, span.start_offset, false);
+  }
+  const int64_t end = span.start_offset + span.length;
+  if (end < len) {
+    bit_util::SetBitsTo(out_bitmap, base + end, len - end, false);
+  }
+  return Status::OK();
+}
+
+Status ClearUnselectedValidity(const FilteredSpan& span, int64_t base, int64_t len,
+                               uint8_t* out_bitmap) {
+  DCHECK_NE(span.bitmap, nullptr);
+  RETURN_NOT_OK(ClearUnselectedValidity(
+      ContiguousSpan{span.start_offset, span.length}, base, len, out_bitmap));
+  BitmapAnd(out_bitmap, base + span.start_offset, span.bitmap, span.bitmap_offset,
+            span.length, base + span.start_offset, out_bitmap);
+  return Status::OK();
+}
+
+Status ClearUnselectedValidity(const DiscreteSpan& span, int64_t base, int64_t len,
+                               uint8_t* out_bitmap) {
+  // Clear only non-selected ranges, preserving selected validity.
+  int64_t cursor = 0;
+  for (int64_t i = 0; i < span.length; ++i) {
+    const int64_t idx = span[i];
+    DCHECK_GE(idx, 0);
+    DCHECK_LT(idx, len);
+    if (idx > cursor) {
+      bit_util::SetBitsTo(out_bitmap, base + cursor, idx - cursor, false);
+    }
+    cursor = idx + 1;
+  }
+  if (cursor < len) {
+    bit_util::SetBitsTo(out_bitmap, base + cursor, len - cursor, false);
+  }
+  return Status::OK();
+}
+
+Status ClearUnselectedValidity(const SelectionSpan& selection, int64_t base, int64_t len,
+                               uint8_t* out_bitmap) {
+  return std::visit(
+      [&](const auto& span) {
+        return ClearUnselectedValidity(span, base, len, out_bitmap);
+      },
+      selection);
+}
+
 class ScalarExecutor : public KernelExecutorImpl<ScalarKernel> {
  public:
   Status Execute(const ExecBatch& batch, ExecListener* listener) override {
@@ -1178,116 +1220,73 @@ class ScalarExecutor : public KernelExecutorImpl<ScalarKernel> {
     if (out->length == 0) {
       return Status::OK();
     }
-	    if (out->type->layout().buffers.empty() ||
-	        out->type->layout().buffers[0].kind != DataTypeLayout::BITMAP) {
-	      // Types without a top-level validity bitmap (e.g. unions) are not yet
-	      // handled here.
-	      return Status::OK();
-	    }
-	    const int64_t selected_count = SelectedCount(selection);
-	    const int64_t base = out->offset;
-	    const int64_t len = out->length;
+    if (out->type->layout().buffers.empty() ||
+        out->type->layout().buffers[0].kind != DataTypeLayout::BITMAP) {
+      // Types without a top-level validity bitmap (e.g. unions) are not yet
+      // handled here.
+      return Status::OK();
+    }
+    const int64_t selected_count = SelectedCount(selection);
+    const int64_t base = out->offset;
+    const int64_t len = out->length;
 
-	    if (selected_count == len) {
-	      // No rows are unselected in this span. Still, an OUTPUT_NOT_NULL kernel may rely on
-	      // the executor to ensure the preallocated validity is set to all-valid.
-	      if (kernel_->null_handling == NullHandling::OUTPUT_NOT_NULL) {
-	        if (uint8_t* out_bitmap = out->buffers[0].data) {
-	          bit_util::SetBitsTo(out_bitmap, base, len, true);
-	        }
-	        out->null_count = 0;
-	      }
-	      return Status::OK();
-	    }
+    if (selected_count == len) {
+      // No rows are unselected in this span. Still, an OUTPUT_NOT_NULL kernel may rely on
+      // the executor to ensure the preallocated validity is set to all-valid.
+      if (kernel_->null_handling == NullHandling::OUTPUT_NOT_NULL) {
+        if (uint8_t* out_bitmap = out->buffers[0].data) {
+          bit_util::SetBitsTo(out_bitmap, base, len, true);
+        }
+        out->null_count = 0;
+      }
+      return Status::OK();
+    }
 
-	    uint8_t* out_bitmap = out->buffers[0].data;
-	    DCHECK_NE(out_bitmap, nullptr);
+    uint8_t* out_bitmap = out->buffers[0].data;
+    DCHECK_NE(out_bitmap, nullptr);
 
-	    if (kernel_->null_handling == NullHandling::OUTPUT_NOT_NULL) {
-	      // The kernel promises all selected rows are valid; only the selection introduces
-	      // nulls.
-	      bit_util::SetBitsTo(out_bitmap, base, len, false);
-	      VisitSelectionSpanInline(selection,
-	                               [&](int64_t i) { bit_util::SetBit(out_bitmap, base + i); });
-	      out->null_count = len - selected_count;
-	      return Status::OK();
-	    }
+    if (kernel_->null_handling == NullHandling::OUTPUT_NOT_NULL) {
+      // The kernel promises all selected rows are valid; only the selection introduces
+      // nulls.
+      bit_util::SetBitsTo(out_bitmap, base, len, false);
+      VisitSelectionSpanInline(selection,
+                               [&](int64_t i) { bit_util::SetBit(out_bitmap, base + i); });
+      out->null_count = len - selected_count;
+      return Status::OK();
+    }
 
-	    return std::visit(
-	        overloaded{
-            [&](const ContiguousSpan& span) -> Status {
-              if (span.start_offset > 0) {
-                bit_util::SetBitsTo(out_bitmap, base, span.start_offset, false);
-              }
-              const int64_t end = span.start_offset + span.length;
-              if (end < len) {
-                bit_util::SetBitsTo(out_bitmap, base + end, len - end, false);
-              }
-              out->null_count = kUnknownNullCount;
-              return Status::OK();
-            },
-            [&](const FilteredSpan& span) -> Status {
-              DCHECK_NE(span.bitmap, nullptr);
-              if (span.start_offset > 0) {
-                bit_util::SetBitsTo(out_bitmap, base, span.start_offset, false);
-              }
-              const int64_t end = span.start_offset + span.length;
-              if (end < len) {
-                bit_util::SetBitsTo(out_bitmap, base + end, len - end, false);
-              }
-              BitmapAnd(out_bitmap, base + span.start_offset, span.bitmap, span.bitmap_offset,
-                        span.length, base + span.start_offset, out_bitmap);
-              out->null_count = kUnknownNullCount;
-              return Status::OK();
-            },
-            [&](const DiscreteSpan& span) -> Status {
-              // Clear only non-selected ranges, preserving selected validity.
-              int64_t cursor = 0;
-              for (int64_t i = 0; i < span.length; ++i) {
-                const int64_t idx = span[i];
-                DCHECK_GE(idx, 0);
-                DCHECK_LT(idx, len);
-                if (idx > cursor) {
-                  bit_util::SetBitsTo(out_bitmap, base + cursor, idx - cursor, false);
-                }
-                cursor = idx + 1;
-              }
-              if (cursor < len) {
-                bit_util::SetBitsTo(out_bitmap, base + cursor, len - cursor, false);
-              }
-              out->null_count = kUnknownNullCount;
-              return Status::OK();
-            }},
-	        selection);
-	  }
+    RETURN_NOT_OK(ClearUnselectedValidity(selection, base, len, out_bitmap));
+    out->null_count = kUnknownNullCount;
+    return Status::OK();
+  }
 
-	  Status ApplySelectionMask(const SelectionSpan& selection, ArrayData* out) {
-	    if (out->length == 0) {
-	      return Status::OK();
-	    }
-	    if (out->type->layout().buffers.empty() ||
-	        out->type->layout().buffers[0].kind != DataTypeLayout::BITMAP) {
-	      return Status::OK();
-	    }
-	    if (out->buffers.empty()) {
-	      return Status::OK();
-	    }
-	    if (out->buffers[0] == nullptr) {
-	      // A missing validity bitmap implies "all valid". Materialize an all-valid bitmap so
-	      // we can mask it with the selection.
-	      const int64_t bitmap_length = out->offset + out->length;
-	      ARROW_ASSIGN_OR_RAISE(out->buffers[0],
-	                            AllocateEmptyBitmap(bitmap_length, exec_context()->memory_pool()));
-	      bit_util::SetBitsTo(out->buffers[0]->mutable_data(), /*start_offset=*/0,
-	                          bitmap_length, true);
-	      out->null_count = 0;
-	    }
-	    ArraySpan out_span(*out);
-	    RETURN_NOT_OK(ApplySelectionMask(selection, &out_span));
-	    out->null_count = out_span.null_count;
-	    return Status::OK();
-	  }
-	};
+  Status ApplySelectionMask(const SelectionSpan& selection, ArrayData* out) {
+    if (out->length == 0) {
+      return Status::OK();
+    }
+    if (out->type->layout().buffers.empty() ||
+        out->type->layout().buffers[0].kind != DataTypeLayout::BITMAP) {
+      return Status::OK();
+    }
+    if (out->buffers.empty()) {
+      return Status::OK();
+    }
+    if (out->buffers[0] == nullptr) {
+      // A missing validity bitmap implies "all valid". Materialize an all-valid bitmap so
+      // we can mask it with the selection.
+      const int64_t bitmap_length = out->offset + out->length;
+      ARROW_ASSIGN_OR_RAISE(out->buffers[0],
+                            AllocateEmptyBitmap(bitmap_length, exec_context()->memory_pool()));
+      bit_util::SetBitsTo(out->buffers[0]->mutable_data(), /*start_offset=*/0,
+                          bitmap_length, true);
+      out->null_count = 0;
+    }
+    ArraySpan out_span(*out);
+    RETURN_NOT_OK(ApplySelectionMask(selection, &out_span));
+    out->null_count = out_span.null_count;
+    return Status::OK();
+  }
+};
 
 namespace {
 

--- a/cpp/src/arrow/compute/exec.cc
+++ b/cpp/src/arrow/compute/exec.cc
@@ -487,10 +487,10 @@ bool ExecSpanIterator::Next(ExecSpan* span, SelectionVectorSpan* selection_span)
     auto indices_end = selection_vector_->indices() + selection_vector_->length();
     DCHECK_LE(indices_begin, indices_end);
     auto indices_limit = std::lower_bound(
-        indices_begin, indices_end, static_cast<int32_t>(position_ + iteration_size));
+        indices_begin, indices_end, static_cast<uint64_t>(position_ + iteration_size));
     int64_t num_indices = indices_limit - indices_begin;
     selection_span->SetSlice(selection_position_, num_indices,
-                             static_cast<int32_t>(position_));
+                             static_cast<uint64_t>(position_));
     selection_position_ += num_indices;
   }
 
@@ -1459,8 +1459,8 @@ const CpuInfo* ExecContext::cpu_info() const { return CpuInfo::GetInstance(); }
 SelectionVector::SelectionVector(std::shared_ptr<ArrayData> data)
     : data_(std::move(data)) {
   DCHECK_NE(data_, nullptr);
-  DCHECK_EQ(data_->type->id(), Type::INT32);
-  indices_ = data_->GetValues<int32_t>(1);
+  DCHECK_EQ(data_->type->id(), Type::UINT64);
+  indices_ = data_->GetValues<uint64_t>(1);
 }
 
 SelectionVector::SelectionVector(const Array& arr) : SelectionVector(arr.data()) {}
@@ -1472,8 +1472,8 @@ Status SelectionVector::Validate(int64_t values_length) const {
     return Status::Invalid("SelectionVector not initialized");
   }
   ARROW_CHECK_NE(indices_, nullptr);
-  if (data_->type->id() != Type::INT32) {
-    return Status::Invalid("SelectionVector must be of type int32");
+  if (data_->type->id() != Type::UINT64) {
+    return Status::Invalid("SelectionVector must be of type uint64");
   }
   if (data_->GetNullCount() != 0) {
     return Status::Invalid("SelectionVector cannot contain nulls");
@@ -1483,14 +1483,10 @@ Status SelectionVector::Validate(int64_t values_length) const {
       return Status::Invalid("SelectionVector indices must be sorted");
     }
   }
-  for (int64_t i = 0; i < length(); ++i) {
-    if (indices_[i] < 0) {
-      return Status::Invalid("SelectionVector indices must be non-negative");
-    }
-  }
   if (values_length >= 0) {
+    const uint64_t values_length_u64 = static_cast<uint64_t>(values_length);
     for (int64_t i = 0; i < length(); ++i) {
-      if (indices_[i] >= values_length) {
+      if (indices_[i] >= values_length_u64) {
         return Status::Invalid("SelectionVector index ", indices_[i],
                                " >= values length ", values_length);
       }
@@ -1500,7 +1496,7 @@ Status SelectionVector::Validate(int64_t values_length) const {
 }
 
 void SelectionVectorSpan::SetSlice(int64_t offset, int64_t length,
-                                   int32_t index_back_shift) {
+                                   uint64_t index_back_shift) {
   DCHECK_NE(indices_, nullptr);
   offset_ = offset;
   length_ = length;

--- a/cpp/src/arrow/compute/exec.cc
+++ b/cpp/src/arrow/compute/exec.cc
@@ -27,6 +27,7 @@
 
 #include "arrow/array/array_base.h"
 #include "arrow/array/array_primitive.h"
+#include "arrow/array/concatenate.h"
 #include "arrow/array/data.h"
 #include "arrow/array/util.h"
 #include "arrow/buffer.h"
@@ -882,41 +883,56 @@ class ScalarExecutor : public KernelExecutorImpl<ScalarKernel> {
       return ExecuteBatch(input, listener);
     }
 
-    ARROW_ASSIGN_OR_RAISE(
-        std::shared_ptr<ArrayData> take_indices_data,
-        batch.selection_vector->ToIndicesArrayData(exec_context()->memory_pool()));
-    Datum take_indices = Datum(std::move(take_indices_data));
-
-    std::vector<Datum> values(batch.num_values());
-    for (int i = 0; i < batch.num_values(); ++i) {
-      if (batch[i].is_scalar()) {
-        // XXX: Skip gather for scalars since it is not currently supported by Take.
-        values[i] = batch[i];
-      } else {
-        ARROW_ASSIGN_OR_RAISE(
-            values[i],
-            Take(batch[i], take_indices, TakeOptions{/*boundcheck=*/false}, exec_context()));
-      }
-    }
+    ARROW_ASSIGN_OR_RAISE(auto values,
+                          batch.selection_vector->GatherValues(batch, exec_context()));
     ARROW_ASSIGN_OR_RAISE(
         ExecBatch input,
         ExecBatch::Make(std::move(values), batch.selection_vector->length()));
 
     DatumAccumulator dense_listener;
     RETURN_NOT_OK(ExecuteBatch(input, &dense_listener));
-    Datum dense_result = WrapResults(input.values, dense_listener.values());
+    std::vector<Datum> dense_outputs = dense_listener.values();
+    const bool dense_split_execution = dense_outputs.size() > 1;
+    Datum dense_result = WrapResults(input.values, dense_outputs);
 
-    // Scatter only accepts signed indices, while our SelectionVector is UInt64.
-    // Cast once here rather than constraining SelectionVector to signed indices.
-    Datum scatter_indices = take_indices;
-    if (scatter_indices.type()->id() == Type::UINT64) {
-      ARROW_ASSIGN_OR_RAISE(
-          scatter_indices,
-          Cast(scatter_indices, int64(), CastOptions::Safe(), exec_context()));
+    ARROW_ASSIGN_OR_RAISE(
+        Datum result,
+        batch.selection_vector->ScatterDenseResult(dense_result, batch.length,
+                                                   exec_context()));
+
+    // Preserve ScalarExecutor chunking semantics:
+    // - If any original inputs were chunked, WrapResults always returns a ChunkedArray.
+    // - If execution yielded multiple output chunks (typically because execution was
+    //   split and results were not fully preallocated), WrapResults returns a
+    //   ChunkedArray.
+    //
+    // The scatter step can return either an Array or a ChunkedArray depending on the
+    // selection backend; normalize to the expected output kind.
+    const bool want_chunked =
+        HaveChunkedArray(batch.values) || dense_split_execution;
+    if (want_chunked) {
+      if (result.is_array()) {
+        auto chunk = MakeArray(result.array());
+        result = Datum(std::make_shared<ChunkedArray>(std::move(chunk)));
+      } else if (result.is_chunked_array() && result.chunked_array()->num_chunks() != 1) {
+        ARROW_ASSIGN_OR_RAISE(auto combined,
+                              Concatenate(result.chunked_array()->chunks(),
+                                          exec_context()->memory_pool()));
+        result = Datum(std::make_shared<ChunkedArray>(std::move(combined)));
+      }
+    } else {
+      if (result.is_chunked_array()) {
+        const auto& carr = *result.chunked_array();
+        if (carr.num_chunks() == 1) {
+          result = Datum(carr.chunk(0)->data());
+        } else {
+          ARROW_ASSIGN_OR_RAISE(
+              auto combined,
+              Concatenate(carr.chunks(), exec_context()->memory_pool()));
+          result = Datum(std::move(combined));
+        }
+      }
     }
-    ARROW_ASSIGN_OR_RAISE(auto result,
-                          Scatter(dense_result, scatter_indices,
-                                  ScatterOptions{/*max_index=*/batch.length - 1}));
     return listener->OnResult(std::move(result));
   }
 
@@ -1038,6 +1054,7 @@ class ScalarExecutor : public KernelExecutorImpl<ScalarKernel> {
   Status SetupPreallocation(int64_t total_length, const std::vector<Datum>& args) {
     output_num_buffers_ = static_cast<int>(output_type_.type->layout().buffers.size());
     auto out_type_id = output_type_.type->id();
+    data_preallocated_.clear();
     // Default to no validity pre-allocation for following cases:
     // - Output Array is NullArray
     // - kernel_->null_handling is COMPUTED_NO_PREALLOCATE or OUTPUT_NOT_NULL
@@ -1061,7 +1078,6 @@ class ScalarExecutor : public KernelExecutorImpl<ScalarKernel> {
       }
     }
     if (kernel_->mem_allocation == MemAllocation::PREALLOCATE) {
-      data_preallocated_.clear();
       ComputeDataPreallocate(*output_type_.type, &data_preallocated_);
     }
 
@@ -1461,83 +1477,651 @@ const CpuInfo* ExecContext::cpu_info() const { return CpuInfo::GetInstance(); }
 // ----------------------------------------------------------------------
 // SelectionVector
 
-SelectionVector::SelectionVector(std::shared_ptr<ArrayData> data)
-    : data_(std::move(data)) {
-  DCHECK_NE(data_, nullptr);
-  DCHECK_EQ(data_->type->id(), Type::UINT64);
-  indices_ = data_->GetValues<uint64_t>(1);
+namespace {
+
+Result<Datum> CoalesceChunkedToArray(Datum value, ExecContext* ctx) {
+  if (ctx == nullptr) {
+    ctx = default_exec_context();
+  }
+  if (!value.is_chunked_array()) {
+    return value;
+  }
+
+  const ChunkedArray& carr = *value.chunked_array();
+  if (carr.num_chunks() == 0) {
+    ARROW_ASSIGN_OR_RAISE(auto empty,
+                          MakeEmptyArray(value.type(), ctx->memory_pool()));
+    return Datum(std::move(empty));
+  }
+  if (carr.num_chunks() == 1) {
+    return Datum(carr.chunk(0)->data());
+  }
+  ARROW_ASSIGN_OR_RAISE(auto combined,
+                        Concatenate(carr.chunks(), ctx->memory_pool()));
+  return Datum(std::move(combined));
 }
+
+}  // namespace
+
+struct SelectionVector::Impl {
+  virtual ~Impl() = default;
+
+  virtual int64_t length() const = 0;
+  virtual Status Validate(int64_t values_length) const = 0;
+  virtual Result<std::shared_ptr<ArrayData>> ToIndicesArrayData(MemoryPool* pool) const = 0;
+  virtual Result<std::vector<Datum>> GatherValues(const ExecBatch& batch,
+                                                  ExecContext* ctx) const = 0;
+  virtual Result<Datum> ScatterDenseResult(const Datum& dense_result,
+                                          int64_t values_length,
+                                          ExecContext* ctx) const = 0;
+  virtual int64_t GetSpanForChunk(uint64_t chunk_start, uint64_t chunk_end,
+                                  int64_t selection_position,
+                                  SelectionSpan* out) const = 0;
+};
+
+struct SelectionVector::IndicesImpl final : public SelectionVector::Impl {
+ public:
+  explicit IndicesImpl(std::shared_ptr<ArrayData> data)
+      : data_(std::move(data)) {
+    DCHECK_NE(data_, nullptr);
+    DCHECK_EQ(data_->type->id(), Type::UINT64);
+    indices_ = data_->GetValues<uint64_t>(1);
+    DCHECK(length() == 0 || indices_ != nullptr);
+  }
+
+  int64_t length() const override { return data_->length; }
+
+  Status Validate(int64_t values_length) const override {
+    if (data_ == nullptr) {
+      return Status::Invalid("SelectionVector not initialized");
+    }
+    if (length() > 0 && indices_ == nullptr) {
+      return Status::Invalid("SelectionVector indices buffer is missing");
+    }
+    if (data_->type->id() != Type::UINT64) {
+      return Status::Invalid("SelectionVector must be of type uint64");
+    }
+    if (data_->GetNullCount() != 0) {
+      return Status::Invalid("SelectionVector cannot contain nulls");
+    }
+    for (int64_t i = 1; i < length(); ++i) {
+      if (indices_[i - 1] >= indices_[i]) {
+        return Status::Invalid("SelectionVector indices must be strictly increasing");
+      }
+    }
+    if (values_length >= 0) {
+      const uint64_t values_length_u64 = static_cast<uint64_t>(values_length);
+      for (int64_t i = 0; i < length(); ++i) {
+        if (indices_[i] >= values_length_u64) {
+          return Status::Invalid("SelectionVector index ", indices_[i],
+                                 " >= values length ", values_length);
+        }
+      }
+    }
+    return Status::OK();
+  }
+
+  Result<std::shared_ptr<ArrayData>> ToIndicesArrayData(MemoryPool* pool) const override {
+    (void)pool;
+    return data_;
+  }
+
+  Result<std::vector<Datum>> GatherValues(const ExecBatch& batch,
+                                         ExecContext* ctx) const override {
+    if (ctx == nullptr) {
+      ctx = default_exec_context();
+    }
+
+    Datum take_indices(data_);
+    std::vector<Datum> values(batch.num_values());
+    for (int i = 0; i < batch.num_values(); ++i) {
+      if (batch[i].is_scalar()) {
+        // XXX: Skip gather for scalars since it is not currently supported by Take.
+        values[i] = batch[i];
+      } else {
+        ARROW_ASSIGN_OR_RAISE(
+            values[i],
+            Take(batch[i], take_indices, TakeOptions{/*boundscheck=*/false}, ctx));
+        // Gather should preserve kind (Array vs ChunkedArray) where possible. Since Take
+        // may return a ChunkedArray for array inputs depending on ExecContext settings,
+        // coalesce to a single Array when the input is an Array.
+        if (batch[i].is_array() && values[i].is_chunked_array()) {
+          ARROW_ASSIGN_OR_RAISE(values[i], CoalesceChunkedToArray(std::move(values[i]), ctx));
+        }
+      }
+    }
+    return values;
+  }
+
+  Result<Datum> ScatterDenseResult(const Datum& dense_result, int64_t values_length,
+                                  ExecContext* ctx) const override {
+    if (ctx == nullptr) {
+      ctx = default_exec_context();
+    }
+    if (values_length < 0) {
+      return Status::Invalid("values_length must be non-negative");
+    }
+
+    // Scatter only accepts signed indices, while our indices are UInt64.
+    Datum scatter_indices(data_);
+    if (scatter_indices.type()->id() == Type::UINT64) {
+      ARROW_ASSIGN_OR_RAISE(scatter_indices,
+                            Cast(scatter_indices, int64(), CastOptions::Safe(), ctx));
+    }
+
+    return Scatter(dense_result, scatter_indices,
+                   ScatterOptions{/*max_index=*/values_length - 1}, ctx);
+  }
+
+  int64_t GetSpanForChunk(uint64_t chunk_start, uint64_t chunk_end,
+                          int64_t selection_position,
+                          SelectionSpan* out) const override {
+    DCHECK_NE(out, nullptr);
+    DCHECK_LE(chunk_start, chunk_end);
+
+    if (length() == 0) {
+      *out = DiscreteSpan{/*indices=*/nullptr, /*length=*/0, chunk_start};
+      return 0;
+    }
+
+    const uint64_t* indices_begin = indices_ + selection_position;
+    const uint64_t* indices_end = indices_ + length();
+    DCHECK_LE(indices_begin, indices_end);
+
+    const uint64_t* indices_limit =
+        std::lower_bound(indices_begin, indices_end, chunk_end);
+    const int64_t num_indices = indices_limit - indices_begin;
+
+    if (num_indices > 0) {
+      const uint64_t first = indices_begin[0];
+      const uint64_t last = indices_begin[num_indices - 1];
+      DCHECK_GE(first, chunk_start);
+      DCHECK_LT(last, chunk_end);
+
+      // If the discrete indices form a contiguous run, represent them as such.
+      // Since Validate enforces strict increasing order, checking (last - first ==
+      // num_indices - 1) is sufficient.
+      if (last - first == static_cast<uint64_t>(num_indices - 1)) {
+        *out = ContiguousSpan{static_cast<int64_t>(first - chunk_start), num_indices};
+      } else {
+        *out = DiscreteSpan{indices_begin, num_indices, chunk_start};
+      }
+    } else {
+      *out = DiscreteSpan{indices_begin, /*length=*/0, chunk_start};
+    }
+
+    return num_indices;
+  }
+
+ private:
+  std::shared_ptr<ArrayData> data_;
+  const uint64_t* indices_ = NULLPTR;
+};
+
+struct SelectionVector::MaskImpl final : public SelectionVector::Impl {
+ public:
+  MaskImpl(std::shared_ptr<ArrayData> mask, int64_t selection_length)
+      : mask_(std::move(mask)), selection_length_(selection_length) {
+    DCHECK_NE(mask_, nullptr);
+    DCHECK_EQ(mask_->type->id(), Type::BOOL);
+    DCHECK_GE(selection_length_, 0);
+    // Boolean values are bit-packed, so always use absolute_offset=0 and apply
+    // any bit offset manually.
+    bitmap_ = mask_->GetValues<uint8_t>(1, /*absolute_offset=*/0);
+    DCHECK(mask_->length == 0 || bitmap_ != nullptr);
+  }
+
+  int64_t length() const override { return selection_length_; }
+
+  Status Validate(int64_t values_length) const override {
+    if (mask_ == nullptr) {
+      return Status::Invalid("SelectionVector not initialized");
+    }
+    if (mask_->type->id() != Type::BOOL) {
+      return Status::Invalid("SelectionVector mask must be of type bool");
+    }
+    if (values_length >= 0 && mask_->length != values_length) {
+      return Status::Invalid("SelectionVector mask length ", mask_->length,
+                             " != values length ", values_length);
+    }
+    if (mask_->GetNullCount() != 0) {
+      return Status::Invalid("SelectionVector mask cannot contain nulls");
+    }
+    const int64_t computed =
+        ::arrow::internal::CountSetBits(bitmap_, mask_->offset, mask_->length);
+    if (computed != selection_length_) {
+      return Status::Invalid("SelectionVector mask selection length mismatch");
+    }
+    return Status::OK();
+  }
+
+  Result<std::shared_ptr<ArrayData>> ToIndicesArrayData(MemoryPool* pool) const override {
+    if (pool == nullptr) {
+      pool = default_memory_pool();
+    }
+    ARROW_ASSIGN_OR_RAISE(auto indices_buf,
+                          AllocateBuffer(selection_length_ * sizeof(uint64_t), pool));
+    auto out = reinterpret_cast<uint64_t*>(indices_buf->mutable_data());
+    int64_t out_pos = 0;
+    for (int64_t i = 0; i < mask_->length; ++i) {
+      if (bit_util::GetBit(bitmap_, mask_->offset + i)) {
+        out[out_pos++] = static_cast<uint64_t>(i);
+      }
+    }
+    DCHECK_EQ(out_pos, selection_length_);
+    return ArrayData::Make(uint64(), selection_length_, {nullptr, std::move(indices_buf)},
+                           /*null_count=*/0);
+  }
+
+  Result<std::vector<Datum>> GatherValues(const ExecBatch& batch,
+                                         ExecContext* ctx) const override {
+    if (ctx == nullptr) {
+      ctx = default_exec_context();
+    }
+    Datum mask(mask_);
+    const FilterOptions opts(FilterOptions::DROP);
+
+    std::vector<Datum> values(batch.num_values());
+    for (int i = 0; i < batch.num_values(); ++i) {
+      if (batch[i].is_scalar()) {
+        values[i] = batch[i];
+      } else {
+        ARROW_ASSIGN_OR_RAISE(values[i], Filter(batch[i], mask, opts, ctx));
+        // Gather should preserve kind (Array vs ChunkedArray) where possible. Since
+        // Filter may return a ChunkedArray for array inputs depending on ExecContext
+        // settings, coalesce to a single Array when the input is an Array.
+        if (batch[i].is_array() && values[i].is_chunked_array()) {
+          ARROW_ASSIGN_OR_RAISE(values[i], CoalesceChunkedToArray(std::move(values[i]), ctx));
+        }
+      }
+    }
+    return values;
+  }
+
+  Result<Datum> ScatterDenseResult(const Datum& dense_result, int64_t values_length,
+                                  ExecContext* ctx) const override {
+    if (ctx == nullptr) {
+      ctx = default_exec_context();
+    }
+    if (values_length < 0) {
+      return Status::Invalid("values_length must be non-negative");
+    }
+
+    // Try a mask-based scatter, which can avoid materializing indices.
+    ARROW_ASSIGN_OR_RAISE(
+        auto base_nulls,
+        MakeArrayOfNull(dense_result.type(), values_length, ctx->memory_pool()));
+    auto maybe_mask_scatter =
+        ReplaceWithMask(Datum(std::move(base_nulls)), Datum(mask_), dense_result, ctx);
+    if (maybe_mask_scatter.ok()) {
+      return maybe_mask_scatter;
+    }
+
+    // Fall back to an indices-based scatter for unsupported types.
+    ARROW_ASSIGN_OR_RAISE(auto indices_data, ToIndicesArrayData(ctx->memory_pool()));
+    Datum scatter_indices(std::move(indices_data));
+    ARROW_ASSIGN_OR_RAISE(scatter_indices,
+                          Cast(scatter_indices, int64(), CastOptions::Safe(), ctx));
+    return Scatter(dense_result, scatter_indices,
+                   ScatterOptions{/*max_index=*/values_length - 1}, ctx);
+  }
+
+  int64_t GetSpanForChunk(uint64_t chunk_start, uint64_t chunk_end,
+                          int64_t selection_position,
+                          SelectionSpan* out) const override {
+    DCHECK_NE(out, nullptr);
+    DCHECK_LE(chunk_start, chunk_end);
+    DCHECK_GE(selection_position, 0);
+    DCHECK_LE(selection_position, selection_length_);
+
+    const uint64_t values_length = static_cast<uint64_t>(mask_->length);
+    const uint64_t clamped_start = std::min(chunk_start, values_length);
+    const uint64_t clamped_end = std::min(chunk_end, values_length);
+    DCHECK_LE(clamped_start, clamped_end);
+    const int64_t chunk_length = static_cast<int64_t>(clamped_end - clamped_start);
+    *out = FilteredSpan{/*start_offset=*/0,
+                        /*length=*/chunk_length,
+                        /*bitmap=*/bitmap_,
+                        /*bitmap_offset=*/static_cast<int64_t>(clamped_start) +
+                            mask_->offset};
+
+    return ::arrow::internal::CountSetBits(
+        bitmap_, static_cast<int64_t>(clamped_start) + mask_->offset, chunk_length);
+  }
+
+ private:
+  std::shared_ptr<ArrayData> mask_;
+  int64_t selection_length_ = 0;
+  const uint8_t* bitmap_ = NULLPTR;
+};
+
+struct SelectionVector::RangesImpl final : public SelectionVector::Impl {
+ public:
+  RangesImpl(std::vector<SelectionRange> ranges, int64_t values_length,
+             std::shared_ptr<ArrayData> mask, int64_t selection_length)
+      : ranges_(std::move(ranges)),
+        values_length_(values_length),
+        mask_(std::move(mask)),
+        selection_length_(selection_length) {
+    DCHECK_NE(mask_, nullptr);
+    DCHECK_EQ(mask_->type->id(), Type::BOOL);
+    // Boolean values are bit-packed, so always use absolute_offset=0 and apply
+    // any bit offset manually.
+    bitmap_ = mask_->GetValues<uint8_t>(1, /*absolute_offset=*/0);
+    DCHECK(mask_->length == 0 || bitmap_ != nullptr);
+  }
+
+  int64_t length() const override { return selection_length_; }
+
+  Status Validate(int64_t values_length) const override {
+    if (values_length >= 0 && values_length != values_length_) {
+      return Status::Invalid("SelectionVector values_length mismatch");
+    }
+    if (mask_->GetNullCount() != 0) {
+      return Status::Invalid("SelectionVector mask cannot contain nulls");
+    }
+    if (mask_->length != values_length_) {
+      return Status::Invalid("SelectionVector mask length mismatch");
+    }
+    uint64_t prev_end = 0;
+    bool first = true;
+    int64_t total = 0;
+    for (const auto& r : ranges_) {
+      if (r.length == 0) {
+        continue;
+      }
+      if (r.start + r.length < r.start) {
+        return Status::Invalid("SelectionVector range overflow");
+      }
+      if (!first && r.start < prev_end) {
+        return Status::Invalid("SelectionVector ranges must be sorted and non-overlapping");
+      }
+      first = false;
+      prev_end = r.start + r.length;
+      if (static_cast<int64_t>(prev_end) > values_length_) {
+        return Status::Invalid("SelectionVector range end out of bounds");
+      }
+      total += static_cast<int64_t>(r.length);
+    }
+    if (total != selection_length_) {
+      return Status::Invalid("SelectionVector ranges selection length mismatch");
+    }
+    const int64_t computed =
+        ::arrow::internal::CountSetBits(bitmap_, mask_->offset, mask_->length);
+    if (computed != selection_length_) {
+      return Status::Invalid("SelectionVector mask selection length mismatch");
+    }
+    return Status::OK();
+  }
+
+  Result<std::shared_ptr<ArrayData>> ToIndicesArrayData(MemoryPool* pool) const override {
+    if (pool == nullptr) {
+      pool = default_memory_pool();
+    }
+    ARROW_ASSIGN_OR_RAISE(auto indices_buf,
+                          AllocateBuffer(selection_length_ * sizeof(uint64_t), pool));
+    auto out = reinterpret_cast<uint64_t*>(indices_buf->mutable_data());
+    int64_t out_pos = 0;
+    for (const auto& r : ranges_) {
+      for (uint64_t i = 0; i < r.length; ++i) {
+        out[out_pos++] = r.start + i;
+      }
+    }
+    DCHECK_EQ(out_pos, selection_length_);
+    return ArrayData::Make(uint64(), selection_length_, {nullptr, std::move(indices_buf)},
+                           /*null_count=*/0);
+  }
+
+  Result<std::vector<Datum>> GatherValues(const ExecBatch& batch,
+                                         ExecContext* ctx) const override {
+    if (ctx == nullptr) {
+      ctx = default_exec_context();
+    }
+
+    std::vector<Datum> values(batch.num_values());
+    for (int i = 0; i < batch.num_values(); ++i) {
+      if (batch[i].is_scalar()) {
+        values[i] = batch[i];
+        continue;
+      }
+
+      if (ranges_.empty()) {
+        // Preserve the value kind (array vs chunked array) where possible.
+        if (batch[i].is_array()) {
+          values[i] = batch[i].array()->Slice(0, 0);
+        } else {
+          values[i] = batch[i].chunked_array()->Slice(0, 0);
+        }
+        continue;
+      }
+
+      if (ranges_.size() == 1) {
+        const auto& r = ranges_[0];
+        const int64_t start = static_cast<int64_t>(r.start);
+        const int64_t len = static_cast<int64_t>(r.length);
+        if (batch[i].is_array()) {
+          values[i] = batch[i].array()->Slice(start, len);
+        } else {
+          values[i] = batch[i].chunked_array()->Slice(start, len);
+        }
+        continue;
+      }
+
+      // Multiple ranges: build a ChunkedArray of slices (zero-copy where possible).
+      if (batch[i].is_array()) {
+        const auto& arr = *batch[i].array();
+        ArrayVector slices;
+        slices.reserve(ranges_.size());
+        for (const auto& r : ranges_) {
+          slices.push_back(MakeArray(arr.Slice(static_cast<int64_t>(r.start),
+                                               static_cast<int64_t>(r.length))));
+        }
+        // Preserve array kind for array inputs, even with multiple ranges.
+        ARROW_ASSIGN_OR_RAISE(auto concatenated,
+                              Concatenate(slices, ctx->memory_pool()));
+        values[i] = Datum(std::move(concatenated));
+      } else {
+        ArrayVector chunks;
+        chunks.reserve(ranges_.size());
+        const auto& carr = *batch[i].chunked_array();
+        for (const auto& r : ranges_) {
+          auto sliced = carr.Slice(static_cast<int64_t>(r.start),
+                                   static_cast<int64_t>(r.length));
+          for (const auto& chunk : sliced->chunks()) {
+            chunks.push_back(chunk);
+          }
+        }
+        values[i] =
+            Datum(std::make_shared<ChunkedArray>(std::move(chunks), batch[i].type()));
+      }
+    }
+
+    return values;
+  }
+
+  Result<Datum> ScatterDenseResult(const Datum& dense_result, int64_t values_length,
+                                  ExecContext* ctx) const override {
+    if (ctx == nullptr) {
+      ctx = default_exec_context();
+    }
+    if (values_length != values_length_) {
+      return Status::Invalid("SelectionVector ranges scatter values_length mismatch");
+    }
+    if (values_length < 0) {
+      return Status::Invalid("values_length must be non-negative");
+    }
+
+    // Prefer a mask-based scatter, which produces a single array and can avoid
+    // materializing indices.
+    ARROW_ASSIGN_OR_RAISE(
+        auto base_nulls,
+        MakeArrayOfNull(dense_result.type(), values_length_, ctx->memory_pool()));
+    auto maybe_mask_scatter =
+        ReplaceWithMask(Datum(std::move(base_nulls)), Datum(mask_), dense_result, ctx);
+    if (maybe_mask_scatter.ok()) {
+      return maybe_mask_scatter;
+    }
+
+    // Fall back to an indices-based scatter for unsupported types.
+    ARROW_ASSIGN_OR_RAISE(auto indices_data, ToIndicesArrayData(ctx->memory_pool()));
+    Datum scatter_indices(std::move(indices_data));
+    ARROW_ASSIGN_OR_RAISE(scatter_indices,
+                          Cast(scatter_indices, int64(), CastOptions::Safe(), ctx));
+    return Scatter(dense_result, scatter_indices,
+                   ScatterOptions{/*max_index=*/values_length_ - 1}, ctx);
+  }
+
+  int64_t GetSpanForChunk(uint64_t chunk_start, uint64_t chunk_end,
+                          int64_t selection_position,
+                          SelectionSpan* out) const override {
+    DCHECK_NE(out, nullptr);
+    DCHECK_LE(chunk_start, chunk_end);
+    DCHECK_GE(selection_position, 0);
+    DCHECK_LE(selection_position, selection_length_);
+
+    const uint64_t values_length = static_cast<uint64_t>(values_length_);
+    const uint64_t clamped_start = std::min(chunk_start, values_length);
+    const uint64_t clamped_end = std::min(chunk_end, values_length);
+    DCHECK_LE(clamped_start, clamped_end);
+    const int64_t chunk_length = static_cast<int64_t>(clamped_end - clamped_start);
+    *out = FilteredSpan{/*start_offset=*/0,
+                        /*length=*/chunk_length,
+                        /*bitmap=*/bitmap_,
+                        /*bitmap_offset=*/static_cast<int64_t>(clamped_start) +
+                            mask_->offset};
+
+    return ::arrow::internal::CountSetBits(
+        bitmap_, static_cast<int64_t>(clamped_start) + mask_->offset, chunk_length);
+  }
+
+ private:
+  std::vector<SelectionRange> ranges_;
+  int64_t values_length_ = 0;
+  std::shared_ptr<ArrayData> mask_;
+  int64_t selection_length_ = 0;
+  const uint8_t* bitmap_ = NULLPTR;
+};
+
+SelectionVector::SelectionVector(std::shared_ptr<ArrayData> data)
+    : impl_(std::make_shared<IndicesImpl>(std::move(data))) {}
+
+SelectionVector::SelectionVector(std::shared_ptr<Impl> impl) : impl_(std::move(impl)) {}
 
 SelectionVector::SelectionVector(const Array& arr) : SelectionVector(arr.data()) {}
 
-int64_t SelectionVector::length() const { return data_->length; }
+Result<std::shared_ptr<SelectionVector>> SelectionVector::FromMask(const Array& mask,
+                                                                   MemoryPool* pool) {
+  if (pool == nullptr) {
+    pool = default_memory_pool();
+  }
+  if (mask.type_id() != Type::BOOL) {
+    return Status::TypeError("SelectionVector mask must be of type bool");
+  }
 
-Status SelectionVector::Validate(int64_t values_length) const {
-  if (data_ == nullptr) {
-    return Status::Invalid("SelectionVector not initialized");
-  }
-  ARROW_CHECK_NE(indices_, nullptr);
-  if (data_->type->id() != Type::UINT64) {
-    return Status::Invalid("SelectionVector must be of type uint64");
-  }
-  if (data_->GetNullCount() != 0) {
-    return Status::Invalid("SelectionVector cannot contain nulls");
-  }
-  for (int64_t i = 1; i < length(); ++i) {
-    if (indices_[i - 1] >= indices_[i]) {
-      return Status::Invalid("SelectionVector indices must be strictly increasing");
+  auto data = mask.data();
+  DCHECK_NE(data, nullptr);
+
+  const int64_t length = data->length;
+  const int64_t offset = data->offset;
+  // Boolean buffers are bit-packed, so always use absolute_offset=0 and apply
+  // the bit offset manually.
+  const uint8_t* values = data->GetValues<uint8_t>(1, /*absolute_offset=*/0);
+  const uint8_t* validity = data->GetValues<uint8_t>(0, /*absolute_offset=*/0);
+
+  std::shared_ptr<ArrayData> normalized;
+  if (offset == 0 && data->GetNullCount() == 0) {
+    normalized = data;
+  } else {
+    std::shared_ptr<Buffer> bitmap;
+    if (data->GetNullCount() == 0) {
+      ARROW_ASSIGN_OR_RAISE(bitmap, AllocateEmptyBitmap(length, pool));
+      CopyBitmap(values, offset, length, bitmap->mutable_data(),
+                           /*dest_offset=*/0);
+    } else {
+      // Treat nulls as false by intersecting validity and values bitmaps.
+      DCHECK_NE(validity, nullptr);
+      ARROW_ASSIGN_OR_RAISE(bitmap, BitmapAnd(pool, values, offset, validity, offset,
+                                              length, /*out_offset=*/0));
     }
+    normalized = ArrayData::Make(boolean(), length, {nullptr, std::move(bitmap)},
+                                 /*null_count=*/0);
   }
-  if (values_length >= 0) {
-    const uint64_t values_length_u64 = static_cast<uint64_t>(values_length);
-    for (int64_t i = 0; i < length(); ++i) {
-      if (indices_[i] >= values_length_u64) {
-        return Status::Invalid("SelectionVector index ", indices_[i],
-                               " >= values length ", values_length);
-      }
-    }
-  }
-  return Status::OK();
+
+  const uint8_t* bitmap = normalized->GetValues<uint8_t>(1, /*absolute_offset=*/0);
+  const int64_t selection_length = ::arrow::internal::CountSetBits(
+      bitmap, normalized->offset, normalized->length);
+  return std::shared_ptr<SelectionVector>(new SelectionVector(
+      std::make_shared<MaskImpl>(std::move(normalized), selection_length)));
 }
 
-Result<std::shared_ptr<ArrayData>> SelectionVector::ToIndicesArrayData(
-    MemoryPool* pool) const {
-  (void)pool;
-  return data_;
+Result<std::shared_ptr<SelectionVector>> SelectionVector::FromRanges(
+    std::vector<SelectionRange> ranges, int64_t values_length, MemoryPool* pool) {
+  if (pool == nullptr) {
+    pool = default_memory_pool();
+  }
+  if (values_length < 0) {
+    return Status::Invalid("values_length must be non-negative");
+  }
+
+  uint64_t prev_end = 0;
+  bool first = true;
+  int64_t selection_length = 0;
+  for (auto& r : ranges) {
+    if (r.length == 0) {
+      continue;
+    }
+    if (r.start + r.length < r.start) {
+      return Status::Invalid("SelectionVector range overflow");
+    }
+    if (!first && r.start < prev_end) {
+      return Status::Invalid("SelectionVector ranges must be sorted and non-overlapping");
+    }
+    first = false;
+    prev_end = r.start + r.length;
+    if (static_cast<int64_t>(prev_end) > values_length) {
+      return Status::Invalid("SelectionVector range end out of bounds");
+    }
+    selection_length += static_cast<int64_t>(r.length);
+  }
+
+  ARROW_ASSIGN_OR_RAISE(auto bitmap, AllocateEmptyBitmap(values_length, pool));
+  for (const auto& r : ranges) {
+    bit_util::SetBitsTo(bitmap->mutable_data(), static_cast<int64_t>(r.start),
+                        static_cast<int64_t>(r.length), true);
+  }
+  auto mask = ArrayData::Make(boolean(), values_length, {nullptr, std::move(bitmap)},
+                              /*null_count=*/0);
+
+  return std::shared_ptr<SelectionVector>(
+      new SelectionVector(std::make_shared<RangesImpl>(
+          std::move(ranges), values_length, std::move(mask), selection_length)));
+}
+
+int64_t SelectionVector::length() const { return impl_->length(); }
+
+Status SelectionVector::Validate(int64_t values_length) const {
+  return impl_->Validate(values_length);
+}
+
+Result<std::shared_ptr<ArrayData>> SelectionVector::ToIndicesArrayData(MemoryPool* pool) const {
+  return impl_->ToIndicesArrayData(pool);
+}
+
+Result<std::vector<Datum>> SelectionVector::GatherValues(const ExecBatch& batch,
+                                                         ExecContext* ctx) const {
+  return impl_->GatherValues(batch, ctx);
+}
+
+Result<Datum> SelectionVector::ScatterDenseResult(const Datum& dense_result,
+                                                  int64_t values_length,
+                                                  ExecContext* ctx) const {
+  return impl_->ScatterDenseResult(dense_result, values_length, ctx);
 }
 
 int64_t SelectionVector::GetSpanForChunk(uint64_t chunk_start, uint64_t chunk_end,
                                         int64_t selection_position,
                                         SelectionSpan* out) const {
-  DCHECK_NE(out, nullptr);
-  DCHECK_LE(chunk_start, chunk_end);
-
-  const uint64_t* indices_begin = indices_ + selection_position;
-  const uint64_t* indices_end = indices_ + length();
-  DCHECK_LE(indices_begin, indices_end);
-
-  const uint64_t* indices_limit = std::lower_bound(indices_begin, indices_end, chunk_end);
-  const int64_t num_indices = indices_limit - indices_begin;
-
-  if (num_indices > 0) {
-    const uint64_t first = indices_begin[0];
-    const uint64_t last = indices_begin[num_indices - 1];
-    DCHECK_GE(first, chunk_start);
-    DCHECK_LT(last, chunk_end);
-
-    // If the discrete indices form a contiguous run, represent them as such.
-    // Since SelectionVector::Validate enforces strict increasing order, checking
-    // (last - first == num_indices - 1) is sufficient.
-    if (last - first == static_cast<uint64_t>(num_indices - 1)) {
-      *out = ContiguousSpan{static_cast<int64_t>(first - chunk_start), num_indices};
-    } else {
-      *out = DiscreteSpan{indices_begin, num_indices, chunk_start};
-    }
-  } else {
-    *out = DiscreteSpan{indices_begin, /*length=*/0, chunk_start};
-  }
-
-  return num_indices;
+  return impl_->GetSpanForChunk(chunk_start, chunk_end, selection_position, out);
 }
 
 Result<Datum> CallFunction(const std::string& func_name, const std::vector<Datum>& args,

--- a/cpp/src/arrow/compute/exec.cc
+++ b/cpp/src/arrow/compute/exec.cc
@@ -481,33 +481,9 @@ bool ExecSpanIterator::Next(ExecSpan* span, SelectionSpan* selection_span) {
     const uint64_t chunk_end =
         static_cast<uint64_t>(position_) + static_cast<uint64_t>(iteration_size);
 
-    const uint64_t* indices_begin = selection_vector_->indices() + selection_position_;
-    const uint64_t* indices_end = selection_vector_->indices() + selection_vector_->length();
-    DCHECK_LE(indices_begin, indices_end);
-
-    const uint64_t* indices_limit = std::lower_bound(indices_begin, indices_end, chunk_end);
-    const int64_t num_indices = indices_limit - indices_begin;
-
-    if (num_indices > 0) {
-      const uint64_t first = indices_begin[0];
-      const uint64_t last = indices_begin[num_indices - 1];
-      DCHECK_GE(first, chunk_start);
-      DCHECK_LT(last, chunk_end);
-
-      // If the discrete indices form a contiguous run, represent them as such.
-      // Since SelectionVector::Validate enforces strict increasing order, checking
-      // (last - first == num_indices - 1) is sufficient.
-      if (last - first == static_cast<uint64_t>(num_indices - 1)) {
-        *selection_span =
-            ContiguousSpan{static_cast<int64_t>(first - chunk_start), num_indices};
-      } else {
-        *selection_span = DiscreteSpan{indices_begin, num_indices, chunk_start};
-      }
-    } else {
-      *selection_span = DiscreteSpan{indices_begin, /*length=*/0, chunk_start};
-    }
-
-    selection_position_ += num_indices;
+    const int64_t consumed = selection_vector_->GetSpanForChunk(
+        chunk_start, chunk_end, selection_position_, selection_span);
+    selection_position_ += consumed;
   }
 
   position_ += iteration_size;
@@ -906,15 +882,20 @@ class ScalarExecutor : public KernelExecutorImpl<ScalarKernel> {
       return ExecuteBatch(input, listener);
     }
 
+    ARROW_ASSIGN_OR_RAISE(
+        std::shared_ptr<ArrayData> take_indices_data,
+        batch.selection_vector->ToIndicesArrayData(exec_context()->memory_pool()));
+    Datum take_indices = Datum(std::move(take_indices_data));
+
     std::vector<Datum> values(batch.num_values());
     for (int i = 0; i < batch.num_values(); ++i) {
       if (batch[i].is_scalar()) {
         // XXX: Skip gather for scalars since it is not currently supported by Take.
         values[i] = batch[i];
       } else {
-        ARROW_ASSIGN_OR_RAISE(values[i],
-                              Take(batch[i], *batch.selection_vector->data(),
-                                   TakeOptions{/*boundcheck=*/false}, exec_context()));
+        ARROW_ASSIGN_OR_RAISE(
+            values[i],
+            Take(batch[i], take_indices, TakeOptions{/*boundcheck=*/false}, exec_context()));
       }
     }
     ARROW_ASSIGN_OR_RAISE(
@@ -927,7 +908,7 @@ class ScalarExecutor : public KernelExecutorImpl<ScalarKernel> {
 
     // Scatter only accepts signed indices, while our SelectionVector is UInt64.
     // Cast once here rather than constraining SelectionVector to signed indices.
-    Datum scatter_indices = batch.selection_vector->data();
+    Datum scatter_indices = take_indices;
     if (scatter_indices.type()->id() == Type::UINT64) {
       ARROW_ASSIGN_OR_RAISE(
           scatter_indices,
@@ -1517,6 +1498,46 @@ Status SelectionVector::Validate(int64_t values_length) const {
     }
   }
   return Status::OK();
+}
+
+Result<std::shared_ptr<ArrayData>> SelectionVector::ToIndicesArrayData(
+    MemoryPool* pool) const {
+  (void)pool;
+  return data_;
+}
+
+int64_t SelectionVector::GetSpanForChunk(uint64_t chunk_start, uint64_t chunk_end,
+                                        int64_t selection_position,
+                                        SelectionSpan* out) const {
+  DCHECK_NE(out, nullptr);
+  DCHECK_LE(chunk_start, chunk_end);
+
+  const uint64_t* indices_begin = indices_ + selection_position;
+  const uint64_t* indices_end = indices_ + length();
+  DCHECK_LE(indices_begin, indices_end);
+
+  const uint64_t* indices_limit = std::lower_bound(indices_begin, indices_end, chunk_end);
+  const int64_t num_indices = indices_limit - indices_begin;
+
+  if (num_indices > 0) {
+    const uint64_t first = indices_begin[0];
+    const uint64_t last = indices_begin[num_indices - 1];
+    DCHECK_GE(first, chunk_start);
+    DCHECK_LT(last, chunk_end);
+
+    // If the discrete indices form a contiguous run, represent them as such.
+    // Since SelectionVector::Validate enforces strict increasing order, checking
+    // (last - first == num_indices - 1) is sufficient.
+    if (last - first == static_cast<uint64_t>(num_indices - 1)) {
+      *out = ContiguousSpan{static_cast<int64_t>(first - chunk_start), num_indices};
+    } else {
+      *out = DiscreteSpan{indices_begin, num_indices, chunk_start};
+    }
+  } else {
+    *out = DiscreteSpan{indices_begin, /*length=*/0, chunk_start};
+  }
+
+  return num_indices;
 }
 
 Result<Datum> CallFunction(const std::string& func_name, const std::vector<Datum>& args,

--- a/cpp/src/arrow/compute/exec.cc
+++ b/cpp/src/arrow/compute/exec.cc
@@ -31,6 +31,7 @@
 #include "arrow/array/util.h"
 #include "arrow/buffer.h"
 #include "arrow/chunked_array.h"
+#include "arrow/compute/cast.h"
 #include "arrow/compute/exec_internal.h"
 #include "arrow/compute/function.h"
 #include "arrow/compute/function_internal.h"
@@ -411,7 +412,7 @@ int64_t ExecSpanIterator::GetNextChunkSpan(int64_t iteration_size, ExecSpan* spa
   return iteration_size;
 }
 
-bool ExecSpanIterator::Next(ExecSpan* span, SelectionVectorSpan* selection_span) {
+bool ExecSpanIterator::Next(ExecSpan* span, SelectionSpan* selection_span) {
   if (!initialized_) {
     span->length = 0;
 
@@ -453,7 +454,7 @@ bool ExecSpanIterator::Next(ExecSpan* span, SelectionVectorSpan* selection_span)
     if (!have_all_scalars_ || promote_if_all_scalars_) {
       if (selection_vector_) {
         DCHECK_NE(selection_span, nullptr);
-        *selection_span = SelectionVectorSpan(selection_vector_->indices());
+        *selection_span = DiscreteSpan(selection_vector_->indices());
       }
     }
 
@@ -489,8 +490,9 @@ bool ExecSpanIterator::Next(ExecSpan* span, SelectionVectorSpan* selection_span)
     auto indices_limit = std::lower_bound(
         indices_begin, indices_end, static_cast<uint64_t>(position_ + iteration_size));
     int64_t num_indices = indices_limit - indices_begin;
-    selection_span->SetSlice(selection_position_, num_indices,
-                             static_cast<uint64_t>(position_));
+    auto* discrete = std::get_if<DiscreteSpan>(selection_span);
+    DCHECK_NE(discrete, nullptr);
+    discrete->SetSlice(selection_position_, num_indices, static_cast<uint64_t>(position_));
     selection_position_ += num_indices;
   }
 
@@ -909,8 +911,16 @@ class ScalarExecutor : public KernelExecutorImpl<ScalarKernel> {
     RETURN_NOT_OK(ExecuteBatch(input, &dense_listener));
     Datum dense_result = WrapResults(input.values, dense_listener.values());
 
+    // Scatter only accepts signed indices, while our SelectionVector is UInt64.
+    // Cast once here rather than constraining SelectionVector to signed indices.
+    Datum scatter_indices = batch.selection_vector->data();
+    if (scatter_indices.type()->id() == Type::UINT64) {
+      ARROW_ASSIGN_OR_RAISE(
+          scatter_indices,
+          Cast(scatter_indices, int64(), CastOptions::Safe(), exec_context()));
+    }
     ARROW_ASSIGN_OR_RAISE(auto result,
-                          Scatter(dense_result, *batch.selection_vector->data(),
+                          Scatter(dense_result, scatter_indices,
                                   ScatterOptions{/*max_index=*/batch.length - 1}));
     return listener->OnResult(std::move(result));
   }
@@ -933,8 +943,8 @@ class ScalarExecutor : public KernelExecutorImpl<ScalarKernel> {
     // eventually skip the creation of ArrayData altogether
     std::shared_ptr<ArrayData> preallocation;
     ExecSpan input;
-    SelectionVectorSpan selection;
-    SelectionVectorSpan* selection_ptr = nullptr;
+    SelectionSpan selection;
+    SelectionSpan* selection_ptr = nullptr;
     if (span_iterator_.have_selection_vector()) {
       selection_ptr = &selection;
     }
@@ -973,7 +983,7 @@ class ScalarExecutor : public KernelExecutorImpl<ScalarKernel> {
     }
   }
 
-  Status ExecuteSingleSpan(const ExecSpan& input, const SelectionVectorSpan* selection,
+  Status ExecuteSingleSpan(const ExecSpan& input, const SelectionSpan* selection,
                            ExecResult* out) {
     ArraySpan* result_span = out->array_span_mutable();
     if (output_type_.type->id() == Type::NA) {
@@ -1000,8 +1010,8 @@ class ScalarExecutor : public KernelExecutorImpl<ScalarKernel> {
     // We will eventually delete the Scalar output path per
     // ARROW-16757.
     ExecSpan input;
-    SelectionVectorSpan selection;
-    SelectionVectorSpan* selection_ptr = nullptr;
+    SelectionSpan selection;
+    SelectionSpan* selection_ptr = nullptr;
     if (span_iterator_.have_selection_vector()) {
       selection_ptr = &selection;
     }
@@ -1087,7 +1097,7 @@ class ScalarExecutor : public KernelExecutorImpl<ScalarKernel> {
 
   // Actually invoke the kernel on the given input span, either selectively if there is a
   // selection or non-selectively otherwise.
-  Status ExecuteKernel(const ExecSpan& input, const SelectionVectorSpan* selection,
+  Status ExecuteKernel(const ExecSpan& input, const SelectionSpan* selection,
                        ExecResult* out) {
     if (selection) {
       DCHECK_NE(kernel_->selective_exec, nullptr);

--- a/cpp/src/arrow/compute/exec.cc
+++ b/cpp/src/arrow/compute/exec.cc
@@ -814,6 +814,37 @@ class KernelExecutorImpl : public KernelExecutor {
   std::vector<BufferPreallocation> data_preallocated_;
 };
 
+int64_t SelectedCount(const ContiguousSpan& span) { return span.length; }
+int64_t SelectedCount(const DiscreteSpan& span) { return span.length; }
+int64_t SelectedCount(const FilteredSpan& span) {
+  DCHECK_NE(span.bitmap, nullptr);
+  return ::arrow::internal::CountSetBits(span.bitmap, span.bitmap_offset, span.length);
+}
+int64_t SelectedCount(const SelectionSpan& selection) {
+  return std::visit([](const auto& span) { return SelectedCount(span); }, selection);
+}
+
+void SetSpanAllNull(ArraySpan* out) {
+  out->null_count = out->length;
+  if (!out->type->layout().buffers.empty() &&
+      out->type->layout().buffers[0].kind == DataTypeLayout::BITMAP &&
+      out->buffers[0].data != nullptr) {
+    bit_util::SetBitsTo(out->buffers[0].data, out->offset, out->length, false);
+  }
+}
+
+class SelectionSpanView {
+ public:
+  explicit SelectionSpanView(const SelectionSpan* selection) : selection_(selection) {}
+
+  bool present() const { return selection_ != nullptr; }
+
+  bool empty() const { return present() && SelectedCount(*selection_) == 0; }
+
+ private:
+  const SelectionSpan* selection_;
+};
+
 class ScalarExecutor : public KernelExecutorImpl<ScalarKernel> {
  public:
   Status Execute(const ExecBatch& batch, ExecListener* listener) override {
@@ -965,14 +996,11 @@ class ScalarExecutor : public KernelExecutorImpl<ScalarKernel> {
       while (span_iterator_.Next(&input, selection_ptr)) {
         // Set absolute output span position and length
         output_span->SetSlice(result_offset, input.length);
-        if (selection_ptr != nullptr) {
-          const int64_t selected_count = SelectedCount(*selection_ptr);
-          if (selected_count == 0) {
-            // No rows are selected in this span; output must be all-null.
-            SetSpanAllNull(output_span);
-            result_offset = span_iterator_.position();
-            continue;
-          }
+        if (SelectionSpanView(selection_ptr).empty()) {
+          // No rows are selected in this span; output must be all-null.
+          SetSpanAllNull(output_span);
+          result_offset = span_iterator_.position();
+          continue;
         }
         RETURN_NOT_OK(ExecuteSingleSpan(input, selection_ptr, &output));
         result_offset = span_iterator_.position();
@@ -1045,7 +1073,7 @@ class ScalarExecutor : public KernelExecutorImpl<ScalarKernel> {
       return EmitResult(all_null->data(), listener);
     };
     while (span_iterator_.Next(&input, selection_ptr)) {
-      if (selection_ptr != nullptr && SelectedCount(*selection_ptr) == 0) {
+      if (SelectionSpanView(selection_ptr).empty()) {
         // No rows are selected in this span; skip kernel execution entirely.
         // Coalesce consecutive empty spans to reduce output chunk overhead.
         pending_empty_length += input.length;
@@ -1174,29 +1202,10 @@ class ScalarExecutor : public KernelExecutorImpl<ScalarKernel> {
 
   ExecSpanIterator span_iterator_;
 
-  static int64_t SelectedCount(const ContiguousSpan& span) { return span.length; }
-  static int64_t SelectedCount(const DiscreteSpan& span) { return span.length; }
-  static int64_t SelectedCount(const FilteredSpan& span) {
-    DCHECK_NE(span.bitmap, nullptr);
-    return ::arrow::internal::CountSetBits(span.bitmap, span.bitmap_offset, span.length);
-  }
-  static int64_t SelectedCount(const SelectionSpan& selection) {
-    return std::visit([](const auto& span) { return SelectedCount(span); }, selection);
-  }
-
-  static void SetSpanAllNull(ArraySpan* out) {
-    out->null_count = out->length;
-    if (!out->type->layout().buffers.empty() &&
-        out->type->layout().buffers[0].kind == DataTypeLayout::BITMAP &&
-        out->buffers[0].data != nullptr) {
-      bit_util::SetBitsTo(out->buffers[0].data, out->offset, out->length, false);
+  Status ApplySelectionMask(const SelectionSpan& selection, ArraySpan* out) {
+    if (out->length == 0) {
+      return Status::OK();
     }
-  }
-
-	  Status ApplySelectionMask(const SelectionSpan& selection, ArraySpan* out) {
-	    if (out->length == 0) {
-	      return Status::OK();
-	    }
 	    if (out->type->layout().buffers.empty() ||
 	        out->type->layout().buffers[0].kind != DataTypeLayout::BITMAP) {
 	      // Types without a top-level validity bitmap (e.g. unions) are not yet

--- a/cpp/src/arrow/compute/exec.cc
+++ b/cpp/src/arrow/compute/exec.cc
@@ -945,8 +945,6 @@ class ScalarExecutor : public KernelExecutorImpl<ScalarKernel> {
     RETURN_NOT_OK(ExecuteBatch(input, &dense_listener));
     Datum dense_result = WrapResults(input.values, dense_listener.values());
 
-    // Scatter only accepts signed indices, while our SelectionVector is UInt64.
-    // Cast once here rather than constraining SelectionVector to signed indices.
     Datum scatter_indices = take_indices;
     if (scatter_indices.type()->id() == Type::UINT64) {
       ARROW_ASSIGN_OR_RAISE(
@@ -1666,8 +1664,8 @@ class IndexSelectionVector final : public SelectionVector {
  public:
   explicit IndexSelectionVector(std::shared_ptr<ArrayData> data) : data_(std::move(data)) {
     DCHECK_NE(data_, nullptr);
-    DCHECK_EQ(data_->type->id(), Type::UINT64);
-    indices_ = data_->GetValues<uint64_t>(1);
+    DCHECK_EQ(data_->type->id(), Type::INT32);
+    indices_ = data_->GetValues<int32_t>(1);
   }
 
   int64_t length() const override { return data_->length; }
@@ -1677,8 +1675,8 @@ class IndexSelectionVector final : public SelectionVector {
       return Status::Invalid("SelectionVector not initialized");
     }
     ARROW_CHECK_NE(indices_, nullptr);
-    if (data_->type->id() != Type::UINT64) {
-      return Status::Invalid("SelectionVector indices must be of type uint64");
+    if (data_->type->id() != Type::INT32) {
+      return Status::Invalid("SelectionVector indices must be of type int32");
     }
     if (data_->GetNullCount() != 0) {
       return Status::Invalid("SelectionVector indices cannot contain nulls");
@@ -1688,10 +1686,14 @@ class IndexSelectionVector final : public SelectionVector {
         return Status::Invalid("SelectionVector indices must be strictly increasing");
       }
     }
+    for (int64_t i = 0; i < length(); ++i) {
+      if (indices_[i] < 0) {
+        return Status::Invalid("SelectionVector indices must be non-negative");
+      }
+    }
     if (values_length >= 0) {
-      const uint64_t values_length_u64 = static_cast<uint64_t>(values_length);
       for (int64_t i = 0; i < length(); ++i) {
-        if (indices_[i] >= values_length_u64) {
+        if (indices_[i] >= values_length) {
           return Status::Invalid("SelectionVector index ", indices_[i],
                                  " >= values length ", values_length);
         }
@@ -1711,29 +1713,33 @@ class IndexSelectionVector final : public SelectionVector {
     DCHECK_NE(out, nullptr);
     DCHECK_LE(chunk_start, chunk_end);
 
-    const uint64_t* indices_begin = indices_ + selection_position;
-    const uint64_t* indices_end = indices_ + length();
+    const int32_t* indices_begin = indices_ + selection_position;
+    const int32_t* indices_end = indices_ + length();
     DCHECK_LE(indices_begin, indices_end);
 
-    const uint64_t* indices_limit = std::lower_bound(indices_begin, indices_end, chunk_end);
+    const int32_t chunk_end_i32 = static_cast<int32_t>(chunk_end);
+    const int32_t* indices_limit =
+        std::lower_bound(indices_begin, indices_end, chunk_end_i32);
     const int64_t num_indices = indices_limit - indices_begin;
 
     if (num_indices > 0) {
-      const uint64_t first = indices_begin[0];
-      const uint64_t last = indices_begin[num_indices - 1];
-      DCHECK_GE(first, chunk_start);
-      DCHECK_LT(last, chunk_end);
+      const int32_t first = indices_begin[0];
+      const int32_t last = indices_begin[num_indices - 1];
+      DCHECK_GE(static_cast<uint64_t>(first), chunk_start);
+      DCHECK_LT(static_cast<uint64_t>(last), chunk_end);
 
       // If the discrete indices form a contiguous run, represent them as such.
       // Since Validate enforces strict increasing order, checking
       // (last - first == num_indices - 1) is sufficient.
-      if (last - first == static_cast<uint64_t>(num_indices - 1)) {
-        *out = ContiguousSpan{static_cast<int64_t>(first - chunk_start), num_indices};
+      if (last - first == static_cast<int32_t>(num_indices - 1)) {
+        *out = ContiguousSpan{static_cast<int64_t>(first) -
+                                  static_cast<int64_t>(chunk_start),
+                              num_indices};
       } else {
-        *out = DiscreteSpan{indices_begin, num_indices, chunk_start};
+        *out = DiscreteSpan{indices_begin, num_indices, static_cast<int32_t>(chunk_start)};
       }
     } else {
-      *out = DiscreteSpan{indices_begin, /*length=*/0, chunk_start};
+      *out = DiscreteSpan{indices_begin, /*length=*/0, static_cast<int32_t>(chunk_start)};
     }
 
     return num_indices;
@@ -1741,7 +1747,7 @@ class IndexSelectionVector final : public SelectionVector {
 
  private:
   std::shared_ptr<ArrayData> data_;
-  const uint64_t* indices_;
+  const int32_t* indices_;
 };
 
 }  // namespace

--- a/cpp/src/arrow/compute/exec.cc
+++ b/cpp/src/arrow/compute/exec.cc
@@ -833,17 +833,9 @@ void SetSpanAllNull(ArraySpan* out) {
   }
 }
 
-class SelectionSpanView {
- public:
-  explicit SelectionSpanView(const SelectionSpan* selection) : selection_(selection) {}
-
-  bool present() const { return selection_ != nullptr; }
-
-  bool empty() const { return present() && SelectedCount(*selection_) == 0; }
-
- private:
-  const SelectionSpan* selection_;
-};
+bool IsEmptySelection(const SelectionSpan* selection) {
+  return selection != nullptr && SelectedCount(*selection) == 0;
+}
 
 class ScalarExecutor : public KernelExecutorImpl<ScalarKernel> {
  public:
@@ -976,7 +968,7 @@ class ScalarExecutor : public KernelExecutorImpl<ScalarKernel> {
       while (span_iterator_.Next(&input, selection_ptr)) {
         // Set absolute output span position and length
         output_span->SetSlice(result_offset, input.length);
-        if (SelectionSpanView(selection_ptr).empty()) {
+        if (IsEmptySelection(selection_ptr)) {
           // No rows are selected in this span; output must be all-null.
           SetSpanAllNull(output_span);
           result_offset = span_iterator_.position();
@@ -1053,7 +1045,7 @@ class ScalarExecutor : public KernelExecutorImpl<ScalarKernel> {
       return EmitResult(all_null->data(), listener);
     };
     while (span_iterator_.Next(&input, selection_ptr)) {
-      if (SelectionSpanView(selection_ptr).empty()) {
+      if (IsEmptySelection(selection_ptr)) {
         // No rows are selected in this span; skip kernel execution entirely.
         // Coalesce consecutive empty spans to reduce output chunk overhead.
         pending_empty_length += input.length;

--- a/cpp/src/arrow/compute/exec.h
+++ b/cpp/src/arrow/compute/exec.h
@@ -168,11 +168,22 @@ struct ARROW_EXPORT DiscreteSpan {
 /// compute::detail::VisitSelectionSpanInline).
 using SelectionSpan = std::variant<ContiguousSpan, FilteredSpan, DiscreteSpan>;
 
+struct ExecBatch;
+
+/// \brief A selection range for selecting rows over an ExecBatch.
+///
+/// Offsets are absolute row indices into the underlying ExecBatch.
+struct ARROW_EXPORT SelectionRange {
+  uint64_t start = 0;
+  uint64_t length = 0;
+};
+
 /// \brief Container for a deferred selection of rows over an ExecBatch.
 ///
-/// This is currently an index-backed selection (UInt64 indices). The public API
-/// avoids exposing the backing representation so that bitmap / run-based
-/// selections can be supported in the future without changing call sites.
+/// This abstraction supports multiple backing representations (e.g. discrete
+/// indices, boolean mask, or ranges). The public API avoids exposing the backing
+/// representation so that future selection formats can be added without changing
+/// call sites.
 ///
 /// Columnar query engines (see e.g. [1]) have found that rather than
 /// materializing filtered data, the filter can instead be converted to a
@@ -182,9 +193,22 @@ using SelectionSpan = std::variant<ContiguousSpan, FilteredSpan, DiscreteSpan>;
 /// [1]: http://cidrdb.org/cidr2005/papers/P19.pdf
 class ARROW_EXPORT SelectionVector {
  public:
+  /// \brief Construct an index-backed selection from a UInt64 ArrayData.
   explicit SelectionVector(std::shared_ptr<ArrayData> data);
 
+  /// \brief Construct an index-backed selection from a UInt64 Array.
   explicit SelectionVector(const Array& arr);
+
+  /// \brief Construct a mask-backed selection from a Boolean array.
+  ///
+  /// Mask nulls are treated as false (i.e. not selected).
+  static Result<std::shared_ptr<SelectionVector>> FromMask(
+      const Array& mask, MemoryPool* pool = default_memory_pool());
+
+  /// \brief Construct a ranges-backed selection from sorted non-overlapping ranges.
+  static Result<std::shared_ptr<SelectionVector>> FromRanges(
+      std::vector<SelectionRange> ranges, int64_t values_length,
+      MemoryPool* pool = default_memory_pool());
 
   /// \brief Number of selected row indices.
   int64_t length() const;
@@ -199,6 +223,14 @@ class ARROW_EXPORT SelectionVector {
   Result<std::shared_ptr<ArrayData>> ToIndicesArrayData(
       MemoryPool* pool = default_memory_pool()) const;
 
+  /// \brief Gather selected rows into a dense sequence of values.
+  Result<std::vector<Datum>> GatherValues(const ExecBatch& batch,
+                                         ExecContext* ctx) const;
+
+  /// \brief Scatter a dense result back into an output of length values_length.
+  Result<Datum> ScatterDenseResult(const Datum& dense_result, int64_t values_length,
+                                  ExecContext* ctx) const;
+
   /// \brief Slice selection for a given contiguous chunk [chunk_start, chunk_end).
   ///
   /// \param[in] chunk_start Absolute row start (inclusive).
@@ -211,8 +243,14 @@ class ARROW_EXPORT SelectionVector {
                           int64_t selection_position, SelectionSpan* out) const;
 
  private:
-  std::shared_ptr<ArrayData> data_;
-  const uint64_t* indices_;
+  struct Impl;
+  struct IndicesImpl;
+  struct MaskImpl;
+  struct RangesImpl;
+
+  explicit SelectionVector(std::shared_ptr<Impl> impl);
+
+  std::shared_ptr<Impl> impl_;
 };
 
 /// An index to represent that a batch does not belong to an ordered stream

--- a/cpp/src/arrow/compute/exec.h
+++ b/cpp/src/arrow/compute/exec.h
@@ -27,6 +27,7 @@
 #include <optional>
 #include <string>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include "arrow/array/data.h"
@@ -184,6 +185,36 @@ class ARROW_EXPORT SelectionVectorSpan {
   int64_t offset_;
   uint64_t index_back_shift_;
 };
+
+/// \brief A selection span representing a contiguous run of selected rows.
+///
+/// Offsets are relative to the current ExecSpan.
+struct ARROW_EXPORT ContiguousSpan {
+  int64_t start_offset = 0;
+  int64_t length = 0;
+};
+
+/// \brief A selection span representing a bitmap over a contiguous range.
+///
+/// Offsets are relative to the current ExecSpan. The bitmap is interpreted as a
+/// bit-packed array where bit i corresponds to row (start_offset + i).
+struct ARROW_EXPORT FilteredSpan {
+  int64_t start_offset = 0;
+  int64_t length = 0;
+  const uint8_t* bitmap = NULLPTR;
+  int64_t bitmap_offset = 0;
+};
+
+/// \brief A selection span representing a discrete set of sorted row indices.
+///
+/// This is currently represented by SelectionVectorSpan.
+using DiscreteSpan = SelectionVectorSpan;
+
+/// \brief A selection span for selective execution.
+///
+/// Kernels should handle all alternatives (e.g. using std::visit or
+/// compute::detail::VisitSelectionSpanInline).
+using SelectionSpan = std::variant<ContiguousSpan, FilteredSpan, DiscreteSpan>;
 
 /// An index to represent that a batch does not belong to an ordered stream
 constexpr int64_t kUnsequencedIndex = -1;

--- a/cpp/src/arrow/compute/exec.h
+++ b/cpp/src/arrow/compute/exec.h
@@ -203,6 +203,19 @@ class ARROW_EXPORT SelectionVector {
   virtual Result<std::shared_ptr<ArrayData>> ToIndicesArrayData(
       MemoryPool* pool = default_memory_pool()) const = 0;
 
+  /// \brief Gather selected input values into a dense argument list.
+  ///
+  /// This is used as the dense fallback for kernels that don't support
+  /// selective execution. Different selection backends can choose different
+  /// compute APIs to produce the dense values.
+  virtual Result<std::vector<Datum>> MakeDenseValues(const std::vector<Datum>& values,
+                                                     ExecContext* ctx) const = 0;
+
+  /// \brief Scatter a dense fallback result back to the original value length.
+  virtual Result<Datum> ScatterDenseResult(const Datum& dense_result,
+                                           int64_t output_length,
+                                           ExecContext* ctx) const = 0;
+
   /// \brief Slice selection for a given contiguous chunk [chunk_start, chunk_end).
   ///
   /// \param[in] chunk_start Absolute row start (inclusive).

--- a/cpp/src/arrow/compute/exec.h
+++ b/cpp/src/arrow/compute/exec.h
@@ -168,22 +168,11 @@ struct ARROW_EXPORT DiscreteSpan {
 /// compute::detail::VisitSelectionSpanInline).
 using SelectionSpan = std::variant<ContiguousSpan, FilteredSpan, DiscreteSpan>;
 
-struct ExecBatch;
-
-/// \brief A selection range for selecting rows over an ExecBatch.
-///
-/// Offsets are absolute row indices into the underlying ExecBatch.
-struct ARROW_EXPORT SelectionRange {
-  uint64_t start = 0;
-  uint64_t length = 0;
-};
-
 /// \brief Container for a deferred selection of rows over an ExecBatch.
 ///
-/// This abstraction supports multiple backing representations (e.g. discrete
-/// indices, boolean mask, or ranges). The public API avoids exposing the backing
-/// representation so that future selection formats can be added without changing
-/// call sites.
+/// This is currently an index-backed selection (UInt64 indices). The public API
+/// avoids exposing the backing representation so that bitmap / run-based
+/// selections can be supported in the future without changing call sites.
 ///
 /// Columnar query engines (see e.g. [1]) have found that rather than
 /// materializing filtered data, the filter can instead be converted to a
@@ -193,22 +182,9 @@ struct ARROW_EXPORT SelectionRange {
 /// [1]: http://cidrdb.org/cidr2005/papers/P19.pdf
 class ARROW_EXPORT SelectionVector {
  public:
-  /// \brief Construct an index-backed selection from a UInt64 ArrayData.
   explicit SelectionVector(std::shared_ptr<ArrayData> data);
 
-  /// \brief Construct an index-backed selection from a UInt64 Array.
   explicit SelectionVector(const Array& arr);
-
-  /// \brief Construct a mask-backed selection from a Boolean array.
-  ///
-  /// Mask nulls are treated as false (i.e. not selected).
-  static Result<std::shared_ptr<SelectionVector>> FromMask(
-      const Array& mask, MemoryPool* pool = default_memory_pool());
-
-  /// \brief Construct a ranges-backed selection from sorted non-overlapping ranges.
-  static Result<std::shared_ptr<SelectionVector>> FromRanges(
-      std::vector<SelectionRange> ranges, int64_t values_length,
-      MemoryPool* pool = default_memory_pool());
 
   /// \brief Number of selected row indices.
   int64_t length() const;
@@ -223,14 +199,6 @@ class ARROW_EXPORT SelectionVector {
   Result<std::shared_ptr<ArrayData>> ToIndicesArrayData(
       MemoryPool* pool = default_memory_pool()) const;
 
-  /// \brief Gather selected rows into a dense sequence of values.
-  Result<std::vector<Datum>> GatherValues(const ExecBatch& batch,
-                                         ExecContext* ctx) const;
-
-  /// \brief Scatter a dense result back into an output of length values_length.
-  Result<Datum> ScatterDenseResult(const Datum& dense_result, int64_t values_length,
-                                  ExecContext* ctx) const;
-
   /// \brief Slice selection for a given contiguous chunk [chunk_start, chunk_end).
   ///
   /// \param[in] chunk_start Absolute row start (inclusive).
@@ -243,14 +211,8 @@ class ARROW_EXPORT SelectionVector {
                           int64_t selection_position, SelectionSpan* out) const;
 
  private:
-  struct Impl;
-  struct IndicesImpl;
-  struct MaskImpl;
-  struct RangesImpl;
-
-  explicit SelectionVector(std::shared_ptr<Impl> impl);
-
-  std::shared_ptr<Impl> impl_;
+  std::shared_ptr<ArrayData> data_;
+  const uint64_t* indices_;
 };
 
 /// An index to represent that a batch does not belong to an ordered stream

--- a/cpp/src/arrow/compute/exec.h
+++ b/cpp/src/arrow/compute/exec.h
@@ -182,22 +182,26 @@ using SelectionSpan = std::variant<ContiguousSpan, FilteredSpan, DiscreteSpan>;
 /// [1]: http://cidrdb.org/cidr2005/papers/P19.pdf
 class ARROW_EXPORT SelectionVector {
  public:
-  explicit SelectionVector(std::shared_ptr<ArrayData> data);
+  virtual ~SelectionVector() = default;
 
-  explicit SelectionVector(const Array& arr);
+  /// \brief Create an index-backed selection vector from UInt64 ArrayData.
+  static std::shared_ptr<SelectionVector> MakeIndices(std::shared_ptr<ArrayData> data);
+
+  /// \brief Create an index-backed selection vector from a UInt64 Array.
+  static std::shared_ptr<SelectionVector> MakeIndices(const Array& arr);
 
   /// \brief Number of selected row indices.
-  int64_t length() const;
+  virtual int64_t length() const = 0;
 
   /// \brief Validate selection (e.g. increasing, non-null, in-bounds).
-  Status Validate(int64_t values_length = -1) const;
+  virtual Status Validate(int64_t values_length = -1) const = 0;
 
   /// \brief Materialize selection as a UInt64 indices ArrayData.
   ///
   /// For index-backed selections this is a cheap accessor. Other future
   /// representations may need to allocate or compute the indices.
-  Result<std::shared_ptr<ArrayData>> ToIndicesArrayData(
-      MemoryPool* pool = default_memory_pool()) const;
+  virtual Result<std::shared_ptr<ArrayData>> ToIndicesArrayData(
+      MemoryPool* pool = default_memory_pool()) const = 0;
 
   /// \brief Slice selection for a given contiguous chunk [chunk_start, chunk_end).
   ///
@@ -207,12 +211,9 @@ class ARROW_EXPORT SelectionVector {
   /// in earlier chunks (rank).
   /// \param[out] out Selection span relative to chunk_start.
   /// \return Number of selected indices consumed from this chunk.
-  int64_t GetSpanForChunk(uint64_t chunk_start, uint64_t chunk_end,
-                          int64_t selection_position, SelectionSpan* out) const;
-
- private:
-  std::shared_ptr<ArrayData> data_;
-  const uint64_t* indices_;
+  virtual int64_t GetSpanForChunk(uint64_t chunk_start, uint64_t chunk_end,
+                                  int64_t selection_position,
+                                  SelectionSpan* out) const = 0;
 };
 
 /// An index to represent that a batch does not belong to an ordered stream

--- a/cpp/src/arrow/compute/exec.h
+++ b/cpp/src/arrow/compute/exec.h
@@ -150,42 +150,6 @@ class ARROW_EXPORT SelectionVector {
   const uint64_t* indices_;
 };
 
-/// \brief A span of a SelectionVector's indices. Can represent a slice of the
-/// underlying indices.
-///
-/// Note that as an indirection of indices to the data in an ExecBatch, when sliced
-/// along with the batch, the indices themselves need to be back-shifted to be relative to
-/// the batch slice (ExecSpan). For example, consider an ExecBatch of 10 rows with a
-/// SelectionVector [0, 1, 9] is to be executed per-8-rows. The first slice of the batch
-/// will have row 0 to row 7 of the original batch with selection slice [0, 1]. The second
-/// slice of the batch will have row 8 and row 9 of the original batch however they are
-/// referred to as row 0 and row 1 by the kernel. Therefore the second selection slice
-/// should be [9 - 8] = [1]. This is done by setting index_back_shift to 8 for the second
-/// selection slice.
-class ARROW_EXPORT SelectionVectorSpan {
- public:
-  explicit SelectionVectorSpan(const uint64_t* indices = NULLPTR, int64_t length = 0,
-                               int64_t offset = 0, uint64_t index_back_shift = 0)
-      : indices_(indices),
-        length_(length),
-        offset_(offset),
-        index_back_shift_(index_back_shift) {}
-
-  void SetSlice(int64_t offset, int64_t length, uint64_t index_back_shift = 0);
-
-  int64_t operator[](int64_t i) const {
-    return static_cast<int64_t>(indices_[i + offset_] - index_back_shift_);
-  }
-
-  int64_t length() const { return length_; }
-
- private:
-  const uint64_t* indices_;
-  int64_t length_;
-  int64_t offset_;
-  uint64_t index_back_shift_;
-};
-
 /// \brief A selection span representing a contiguous run of selected rows.
 ///
 /// Offsets are relative to the current ExecSpan.
@@ -207,8 +171,23 @@ struct ARROW_EXPORT FilteredSpan {
 
 /// \brief A selection span representing a discrete set of sorted row indices.
 ///
-/// This is currently represented by SelectionVectorSpan.
-using DiscreteSpan = SelectionVectorSpan;
+/// Offsets are relative to the current ExecSpan.
+///
+/// When derived from a SelectionVector (whose indices are absolute row ids in the
+/// underlying ExecBatch), the `index_back_shift` is subtracted to make the indices
+/// relative to the current ExecSpan slice. For example, if an ExecBatch of 10 rows
+/// is executed per 8 rows and the selection contains row 9, then the second ExecSpan
+/// slice (rows 8 and 9) should represent this as index 1 by setting
+/// `index_back_shift = 8`.
+struct ARROW_EXPORT DiscreteSpan {
+  const uint64_t* indices = NULLPTR;
+  int64_t length = 0;
+  uint64_t index_back_shift = 0;
+
+  int64_t operator[](int64_t i) const {
+    return static_cast<int64_t>(indices[i] - index_back_shift);
+  }
+};
 
 /// \brief A selection span for selective execution.
 ///

--- a/cpp/src/arrow/compute/exec.h
+++ b/cpp/src/arrow/compute/exec.h
@@ -153,9 +153,9 @@ struct ARROW_EXPORT FilteredSpan {
 /// slice (rows 8 and 9) should represent this as index 1 by setting
 /// `index_back_shift = 8`.
 struct ARROW_EXPORT DiscreteSpan {
-  const uint64_t* indices = NULLPTR;
+  const int32_t* indices = NULLPTR;
   int64_t length = 0;
-  uint64_t index_back_shift = 0;
+  int32_t index_back_shift = 0;
 
   int64_t operator[](int64_t i) const {
     return static_cast<int64_t>(indices[i] - index_back_shift);
@@ -170,7 +170,7 @@ using SelectionSpan = std::variant<ContiguousSpan, FilteredSpan, DiscreteSpan>;
 
 /// \brief Container for a deferred selection of rows over an ExecBatch.
 ///
-/// This is currently an index-backed selection (UInt64 indices). The public API
+/// This is currently an index-backed selection (Int32 indices). The public API
 /// avoids exposing the backing representation so that bitmap / run-based
 /// selections can be supported in the future without changing call sites.
 ///
@@ -184,10 +184,10 @@ class ARROW_EXPORT SelectionVector {
  public:
   virtual ~SelectionVector() = default;
 
-  /// \brief Create an index-backed selection vector from UInt64 ArrayData.
+  /// \brief Create an index-backed selection vector from Int32 ArrayData.
   static std::shared_ptr<SelectionVector> MakeIndices(std::shared_ptr<ArrayData> data);
 
-  /// \brief Create an index-backed selection vector from a UInt64 Array.
+  /// \brief Create an index-backed selection vector from an Int32 Array.
   static std::shared_ptr<SelectionVector> MakeIndices(const Array& arr);
 
   /// \brief Number of selected row indices.
@@ -196,7 +196,7 @@ class ARROW_EXPORT SelectionVector {
   /// \brief Validate selection (e.g. increasing, non-null, in-bounds).
   virtual Status Validate(int64_t values_length = -1) const = 0;
 
-  /// \brief Materialize selection as a UInt64 indices ArrayData.
+  /// \brief Materialize selection as an Int32 indices ArrayData.
   ///
   /// For index-backed selections this is a cheap accessor. Other future
   /// representations may need to allocate or compute the indices.

--- a/cpp/src/arrow/compute/exec.h
+++ b/cpp/src/arrow/compute/exec.h
@@ -139,14 +139,14 @@ class ARROW_EXPORT SelectionVector {
   explicit SelectionVector(const Array& arr);
 
   std::shared_ptr<ArrayData> data() const { return data_; }
-  const int32_t* indices() const { return indices_; }
+  const uint64_t* indices() const { return indices_; }
   int64_t length() const;
 
   Status Validate(int64_t values_length = -1) const;
 
  private:
   std::shared_ptr<ArrayData> data_;
-  const int32_t* indices_;
+  const uint64_t* indices_;
 };
 
 /// \brief A span of a SelectionVector's indices. Can represent a slice of the
@@ -163,26 +163,26 @@ class ARROW_EXPORT SelectionVector {
 /// selection slice.
 class ARROW_EXPORT SelectionVectorSpan {
  public:
-  explicit SelectionVectorSpan(const int32_t* indices = NULLPTR, int64_t length = 0,
-                               int64_t offset = 0, int32_t index_back_shift = 0)
+  explicit SelectionVectorSpan(const uint64_t* indices = NULLPTR, int64_t length = 0,
+                               int64_t offset = 0, uint64_t index_back_shift = 0)
       : indices_(indices),
         length_(length),
         offset_(offset),
         index_back_shift_(index_back_shift) {}
 
-  void SetSlice(int64_t offset, int64_t length, int32_t index_back_shift = 0);
+  void SetSlice(int64_t offset, int64_t length, uint64_t index_back_shift = 0);
 
-  int32_t operator[](int64_t i) const {
-    return indices_[i + offset_] - index_back_shift_;
+  int64_t operator[](int64_t i) const {
+    return static_cast<int64_t>(indices_[i + offset_] - index_back_shift_);
   }
 
   int64_t length() const { return length_; }
 
  private:
-  const int32_t* indices_;
+  const uint64_t* indices_;
   int64_t length_;
   int64_t offset_;
-  int32_t index_back_shift_;
+  uint64_t index_back_shift_;
 };
 
 /// An index to represent that a batch does not belong to an ordered stream
@@ -238,9 +238,7 @@ struct ARROW_EXPORT ExecBatch {
 
   /// The semantic length of the ExecBatch. When the values are all scalars,
   /// the length should be set to 1 for non-aggregate kernels, otherwise the
-  /// length is taken from the array values, except when there is a selection
-  /// vector. When there is a selection vector set, the length of the batch is
-  /// the length of the selection. Aggregate kernels can have an ExecBatch
+  /// length is taken from the array values. Aggregate kernels can have an ExecBatch
   /// formed by projecting just the partition columns from a batch in which
   /// case, it would have scalar rows with length greater than 1.
   ///
@@ -251,8 +249,9 @@ struct ARROW_EXPORT ExecBatch {
   /// A deferred filter represented as an array of indices into the values.
   ///
   /// For example, the filter [true, true, false, true] would be represented as
-  /// the selection vector [0, 1, 3]. When the selection vector is set,
-  /// ExecBatch::length is equal to the length of this array.
+  /// the selection vector [0, 1, 3]. When the selection vector is set, the indices
+  /// refer to row positions in the underlying values (and may be smaller than the
+  /// underlying length).
   std::shared_ptr<SelectionVector> selection_vector;
 
   /// \brief index of this batch in a sorted stream of batches

--- a/cpp/src/arrow/compute/exec.h
+++ b/cpp/src/arrow/compute/exec.h
@@ -123,33 +123,6 @@ class ARROW_EXPORT ExecContext {
 // TODO: Consider standardizing on uint16 selection vectors and only use them
 // when we can ensure that each value is 64K length or smaller
 
-/// \brief Container for an array of value selection indices that were
-/// materialized from a filter.
-///
-/// Columnar query engines (see e.g. [1]) have found that rather than
-/// materializing filtered data, the filter can instead be converted to an
-/// array of the "on" indices and then "fusing" these indices in operator
-/// implementations. This is especially relevant for aggregations but also
-/// applies to scalar operations.
-///
-/// [1]: http://cidrdb.org/cidr2005/papers/P19.pdf
-class ARROW_EXPORT SelectionVector {
- public:
-  explicit SelectionVector(std::shared_ptr<ArrayData> data);
-
-  explicit SelectionVector(const Array& arr);
-
-  std::shared_ptr<ArrayData> data() const { return data_; }
-  const uint64_t* indices() const { return indices_; }
-  int64_t length() const;
-
-  Status Validate(int64_t values_length = -1) const;
-
- private:
-  std::shared_ptr<ArrayData> data_;
-  const uint64_t* indices_;
-};
-
 /// \brief A selection span representing a contiguous run of selected rows.
 ///
 /// Offsets are relative to the current ExecSpan.
@@ -194,6 +167,53 @@ struct ARROW_EXPORT DiscreteSpan {
 /// Kernels should handle all alternatives (e.g. using std::visit or
 /// compute::detail::VisitSelectionSpanInline).
 using SelectionSpan = std::variant<ContiguousSpan, FilteredSpan, DiscreteSpan>;
+
+/// \brief Container for a deferred selection of rows over an ExecBatch.
+///
+/// This is currently an index-backed selection (UInt64 indices). The public API
+/// avoids exposing the backing representation so that bitmap / run-based
+/// selections can be supported in the future without changing call sites.
+///
+/// Columnar query engines (see e.g. [1]) have found that rather than
+/// materializing filtered data, the filter can instead be converted to a
+/// selection and then "fused" in operator implementations. This is especially
+/// relevant for aggregations but also applies to scalar operations.
+///
+/// [1]: http://cidrdb.org/cidr2005/papers/P19.pdf
+class ARROW_EXPORT SelectionVector {
+ public:
+  explicit SelectionVector(std::shared_ptr<ArrayData> data);
+
+  explicit SelectionVector(const Array& arr);
+
+  /// \brief Number of selected row indices.
+  int64_t length() const;
+
+  /// \brief Validate selection (e.g. increasing, non-null, in-bounds).
+  Status Validate(int64_t values_length = -1) const;
+
+  /// \brief Materialize selection as a UInt64 indices ArrayData.
+  ///
+  /// For index-backed selections this is a cheap accessor. Other future
+  /// representations may need to allocate or compute the indices.
+  Result<std::shared_ptr<ArrayData>> ToIndicesArrayData(
+      MemoryPool* pool = default_memory_pool()) const;
+
+  /// \brief Slice selection for a given contiguous chunk [chunk_start, chunk_end).
+  ///
+  /// \param[in] chunk_start Absolute row start (inclusive).
+  /// \param[in] chunk_end Absolute row end (exclusive).
+  /// \param[in] selection_position Number of selected indices already consumed
+  /// in earlier chunks (rank).
+  /// \param[out] out Selection span relative to chunk_start.
+  /// \return Number of selected indices consumed from this chunk.
+  int64_t GetSpanForChunk(uint64_t chunk_start, uint64_t chunk_end,
+                          int64_t selection_position, SelectionSpan* out) const;
+
+ private:
+  std::shared_ptr<ArrayData> data_;
+  const uint64_t* indices_;
+};
 
 /// An index to represent that a batch does not belong to an ordered stream
 constexpr int64_t kUnsequencedIndex = -1;

--- a/cpp/src/arrow/compute/exec_benchmark.cc
+++ b/cpp/src/arrow/compute/exec_benchmark.cc
@@ -143,8 +143,8 @@ std::shared_ptr<ChunkedArray> MakeChunkedInt32(int64_t num_rows, int64_t chunk_s
 }
 
 std::shared_ptr<SelectionVector> MakeSelectionVectorFromIndices(
-    const std::vector<uint64_t>& indices) {
-  UInt64Builder builder;
+    const std::vector<int32_t>& indices) {
+  Int32Builder builder;
   ARROW_CHECK_OK(builder.Reserve(static_cast<int64_t>(indices.size())));
   ARROW_CHECK_OK(
       builder.AppendValues(indices.data(), static_cast<int64_t>(indices.size())));
@@ -154,7 +154,7 @@ std::shared_ptr<SelectionVector> MakeSelectionVectorFromIndices(
 }
 
 std::shared_ptr<SelectionVector> MakeSelectionVectorPrefix(int64_t length) {
-  auto res = gen::Step<uint64_t>()->Generate(length);
+  auto res = gen::Step<int32_t>()->Generate(length);
   ARROW_CHECK_OK(res.status());
   auto arr = res.ValueUnsafe();
   return SelectionVector::MakeIndices(*arr);
@@ -164,17 +164,17 @@ std::shared_ptr<SelectionVector> MakeSelectionVectorRandomSortedUnique(
     int64_t length, int64_t selected_length, uint64_t seed = 0x4d595df4d0f33173ULL) {
   ARROW_CHECK_GE(length, 0);
   selected_length = std::max<int64_t>(0, std::min<int64_t>(selected_length, length));
-  std::vector<uint64_t> indices;
+  std::vector<int32_t> indices;
   indices.reserve(static_cast<size_t>(selected_length));
   if (selected_length == 0) {
     return MakeSelectionVectorFromIndices(indices);
   }
 
   std::mt19937_64 rng(seed);
-  std::uniform_int_distribution<uint64_t> dist(0, static_cast<uint64_t>(length - 1));
+  std::uniform_int_distribution<int32_t> dist(0, static_cast<int32_t>(length - 1));
   std::vector<uint8_t> seen(static_cast<size_t>(length), 0);
   while (static_cast<int64_t>(indices.size()) < selected_length) {
-    const uint64_t v = dist(rng);
+    const int32_t v = dist(rng);
     auto& flag = seen[static_cast<size_t>(v)];
     if (!flag) {
       flag = 1;
@@ -189,7 +189,7 @@ std::shared_ptr<SelectionVector> MakeSelectionVectorOnePerChunk(const ChunkedArr
                                                                 int64_t selected_length) {
   const int64_t length = input.length();
   selected_length = std::max<int64_t>(0, std::min<int64_t>(selected_length, length));
-  std::vector<uint64_t> indices;
+  std::vector<int32_t> indices;
   indices.reserve(static_cast<size_t>(selected_length));
   if (selected_length == 0) {
     return MakeSelectionVectorFromIndices(indices);
@@ -237,7 +237,7 @@ std::shared_ptr<SelectionVector> MakeSelectionVectorOnePerChunk(const ChunkedArr
     // Pick a deterministic position within the chunk (not always 0), to avoid
     // accidentally creating large contiguous runs across chunks when chunk_size is big.
     const int64_t local = static_cast<int64_t>(chunk_id % chunk_len);
-    indices.push_back(static_cast<uint64_t>(chunk_start + local));
+    indices.push_back(static_cast<int32_t>(chunk_start + local));
 
     // If we exhausted all chunks, fall back to random fill (still sorted/unique)
     // to reach selected_length.
@@ -252,13 +252,13 @@ std::shared_ptr<SelectionVector> MakeSelectionVectorOnePerChunk(const ChunkedArr
     // Since we've already picked <= num_chunks indices, this is cheap for our sizes.
     std::sort(indices.begin(), indices.end());
     std::vector<uint8_t> seen(static_cast<size_t>(length), 0);
-    for (uint64_t v : indices) {
+    for (int32_t v : indices) {
       seen[static_cast<size_t>(v)] = 1;
     }
     std::mt19937_64 rng(0x9e3779b97f4a7c15ULL);
-    std::uniform_int_distribution<uint64_t> dist(0, static_cast<uint64_t>(length - 1));
+    std::uniform_int_distribution<int32_t> dist(0, static_cast<int32_t>(length - 1));
     while (static_cast<int64_t>(indices.size()) < selected_length) {
-      const uint64_t v = dist(rng);
+      const int32_t v = dist(rng);
       auto& flag = seen[static_cast<size_t>(v)];
       if (!flag) {
         flag = 1;

--- a/cpp/src/arrow/compute/exec_benchmark.cc
+++ b/cpp/src/arrow/compute/exec_benchmark.cc
@@ -150,14 +150,14 @@ std::shared_ptr<SelectionVector> MakeSelectionVectorFromIndices(
       builder.AppendValues(indices.data(), static_cast<int64_t>(indices.size())));
   std::shared_ptr<Array> arr;
   ARROW_CHECK_OK(builder.Finish(&arr));
-  return std::make_shared<SelectionVector>(*arr);
+  return SelectionVector::MakeIndices(*arr);
 }
 
 std::shared_ptr<SelectionVector> MakeSelectionVectorPrefix(int64_t length) {
   auto res = gen::Step<uint64_t>()->Generate(length);
   ARROW_CHECK_OK(res.status());
   auto arr = res.ValueUnsafe();
-  return std::make_shared<SelectionVector>(*arr);
+  return SelectionVector::MakeIndices(*arr);
 }
 
 std::shared_ptr<SelectionVector> MakeSelectionVectorRandomSortedUnique(

--- a/cpp/src/arrow/compute/exec_benchmark.cc
+++ b/cpp/src/arrow/compute/exec_benchmark.cc
@@ -73,13 +73,13 @@ Status SpinExec(KernelContext* ctx, const ExecSpan& span, ExecResult* out) {
 }
 
 Status SpinSelectiveExec(KernelContext* ctx, const ExecSpan& span,
-                         const SelectionVectorSpan& selection_span, ExecResult* out) {
+                         const SelectionSpan& selection, ExecResult* out) {
   ARROW_CHECK_EQ(span.num_values(), 1);
   const auto& arg = span[0];
   ARROW_CHECK(arg.is_array());
 
   int64_t count = SpinState::Get(ctx).count;
-  detail::VisitSelectionVectorSpanInline(selection_span, [&](int64_t i) { Spin(count); });
+  detail::VisitSelectionSpanInline(selection, [&](int64_t i) { Spin(count); });
   *out->array_data_mutable() = *arg.array.ToArrayData();
   return Status::OK();
 }

--- a/cpp/src/arrow/compute/exec_benchmark.cc
+++ b/cpp/src/arrow/compute/exec_benchmark.cc
@@ -17,11 +17,20 @@
 
 #include "benchmark/benchmark.h"
 
+#include <algorithm>
+#include <cstdint>
+#include <random>
+#include <string>
+#include <vector>
+
 #include "arrow/compute/exec_internal.h"
 #include "arrow/compute/expression.h"
 #include "arrow/compute/function_internal.h"
 #include "arrow/compute/kernels/codegen_internal.h"
 #include "arrow/compute/registry.h"
+#include "arrow/array/builder_primitive.h"
+#include "arrow/chunked_array.h"
+#include "arrow/datum.h"
 #include "arrow/testing/generator.h"
 #include "arrow/util/logging.h"
 
@@ -114,26 +123,189 @@ Status RegisterSpinFunction() {
   return Status::OK();
 }
 
-std::shared_ptr<SelectionVector> MakeSelectionVectorTo(int64_t length) {
+enum class SelectionPattern : int8_t {
+  kPrefix,
+  // Spread indices across chunks with (at most) one selected row per chunk, which
+  // maximizes chunk-boundary overhead for a given number of selected rows.
+  kOnePerChunk,
+  // Random unique indices distributed across the full length (sorted).
+  kRandomSortedUnique,
+};
+
+std::shared_ptr<ChunkedArray> MakeChunkedInt32(int64_t num_rows, int64_t chunk_size) {
+  ARROW_CHECK_GT(chunk_size, 0);
+  ArrayVector chunks;
+  for (int64_t offset = 0; offset < num_rows; offset += chunk_size) {
+    const int64_t len = std::min(chunk_size, num_rows - offset);
+    chunks.push_back(ConstantArrayGenerator::Int32(len, 0));
+  }
+  return std::make_shared<ChunkedArray>(std::move(chunks), int32());
+}
+
+std::shared_ptr<SelectionVector> MakeSelectionVectorFromIndices(
+    const std::vector<uint64_t>& indices) {
+  UInt64Builder builder;
+  ARROW_CHECK_OK(builder.Reserve(static_cast<int64_t>(indices.size())));
+  ARROW_CHECK_OK(
+      builder.AppendValues(indices.data(), static_cast<int64_t>(indices.size())));
+  std::shared_ptr<Array> arr;
+  ARROW_CHECK_OK(builder.Finish(&arr));
+  return std::make_shared<SelectionVector>(*arr);
+}
+
+std::shared_ptr<SelectionVector> MakeSelectionVectorPrefix(int64_t length) {
   auto res = gen::Step<uint64_t>()->Generate(length);
   ARROW_CHECK_OK(res.status());
   auto arr = res.ValueUnsafe();
   return std::make_shared<SelectionVector>(*arr);
 }
 
+std::shared_ptr<SelectionVector> MakeSelectionVectorRandomSortedUnique(
+    int64_t length, int64_t selected_length, uint64_t seed = 0x4d595df4d0f33173ULL) {
+  ARROW_CHECK_GE(length, 0);
+  selected_length = std::max<int64_t>(0, std::min<int64_t>(selected_length, length));
+  std::vector<uint64_t> indices;
+  indices.reserve(static_cast<size_t>(selected_length));
+  if (selected_length == 0) {
+    return MakeSelectionVectorFromIndices(indices);
+  }
+
+  std::mt19937_64 rng(seed);
+  std::uniform_int_distribution<uint64_t> dist(0, static_cast<uint64_t>(length - 1));
+  std::vector<uint8_t> seen(static_cast<size_t>(length), 0);
+  while (static_cast<int64_t>(indices.size()) < selected_length) {
+    const uint64_t v = dist(rng);
+    auto& flag = seen[static_cast<size_t>(v)];
+    if (!flag) {
+      flag = 1;
+      indices.push_back(v);
+    }
+  }
+  std::sort(indices.begin(), indices.end());
+  return MakeSelectionVectorFromIndices(indices);
+}
+
+std::shared_ptr<SelectionVector> MakeSelectionVectorOnePerChunk(const ChunkedArray& input,
+                                                                int64_t selected_length) {
+  const int64_t length = input.length();
+  selected_length = std::max<int64_t>(0, std::min<int64_t>(selected_length, length));
+  std::vector<uint64_t> indices;
+  indices.reserve(static_cast<size_t>(selected_length));
+  if (selected_length == 0) {
+    return MakeSelectionVectorFromIndices(indices);
+  }
+
+  const int num_chunks = input.num_chunks();
+  if (num_chunks == 0) {
+    return MakeSelectionVectorFromIndices(indices);
+  }
+
+  // Choose (up to) one index per distinct chunk, spreading chunk ids across the full
+  // range. We then sort indices to satisfy SelectionVector's strict-increasing contract.
+  const uint64_t stride = 1315423911ULL;  // odd constant, deterministic
+  std::vector<int64_t> chunk_offsets(static_cast<size_t>(num_chunks));
+  std::vector<int> eligible_chunk_ids;
+  eligible_chunk_ids.reserve(static_cast<size_t>(num_chunks));
+  int64_t offset = 0;
+  for (int i = 0; i < num_chunks; ++i) {
+    chunk_offsets[static_cast<size_t>(i)] = offset;
+    const int64_t chunk_len = input.chunk(i)->length();
+    if (chunk_len > 0) {
+      eligible_chunk_ids.push_back(i);
+    }
+    offset += chunk_len;
+  }
+
+  if (eligible_chunk_ids.empty()) {
+    return MakeSelectionVectorFromIndices(indices);
+  }
+
+  std::vector<uint8_t> chunk_used(eligible_chunk_ids.size(), 0);
+  uint64_t k = 0;
+  while (static_cast<int64_t>(indices.size()) < selected_length) {
+    const size_t idx =
+        static_cast<size_t>((k * stride) % static_cast<uint64_t>(eligible_chunk_ids.size()));
+    const int chunk_id = eligible_chunk_ids[idx];
+    ++k;
+    auto& used = chunk_used[idx];
+    if (used) {
+      continue;
+    }
+    used = 1;
+    const int64_t chunk_start = chunk_offsets[static_cast<size_t>(chunk_id)];
+    const int64_t chunk_len = input.chunk(chunk_id)->length();
+    // Pick a deterministic position within the chunk (not always 0), to avoid
+    // accidentally creating large contiguous runs across chunks when chunk_size is big.
+    const int64_t local = static_cast<int64_t>(chunk_id % chunk_len);
+    indices.push_back(static_cast<uint64_t>(chunk_start + local));
+
+    // If we exhausted all chunks, fall back to random fill (still sorted/unique)
+    // to reach selected_length.
+    if (static_cast<int>(indices.size()) ==
+        static_cast<int>(eligible_chunk_ids.size())) {
+      break;
+    }
+  }
+
+  if (static_cast<int64_t>(indices.size()) < selected_length) {
+    // Fill remaining indices randomly across the whole length, avoiding duplicates.
+    // Since we've already picked <= num_chunks indices, this is cheap for our sizes.
+    std::sort(indices.begin(), indices.end());
+    std::vector<uint8_t> seen(static_cast<size_t>(length), 0);
+    for (uint64_t v : indices) {
+      seen[static_cast<size_t>(v)] = 1;
+    }
+    std::mt19937_64 rng(0x9e3779b97f4a7c15ULL);
+    std::uniform_int_distribution<uint64_t> dist(0, static_cast<uint64_t>(length - 1));
+    while (static_cast<int64_t>(indices.size()) < selected_length) {
+      const uint64_t v = dist(rng);
+      auto& flag = seen[static_cast<size_t>(v)];
+      if (!flag) {
+        flag = 1;
+        indices.push_back(v);
+      }
+    }
+    std::sort(indices.begin(), indices.end());
+  } else {
+    std::sort(indices.begin(), indices.end());
+  }
+
+  return MakeSelectionVectorFromIndices(indices);
+}
+
+std::shared_ptr<SelectionVector> MakeSelectionVector(SelectionPattern pattern,
+                                                     const Datum& input,
+                                                     int64_t selected_length) {
+  const int64_t length = input.length();
+  switch (pattern) {
+    case SelectionPattern::kPrefix:
+      return MakeSelectionVectorPrefix(selected_length);
+    case SelectionPattern::kOnePerChunk:
+      if (input.is_chunked_array()) {
+        return MakeSelectionVectorOnePerChunk(*input.chunked_array(), selected_length);
+      }
+      // For non-chunked inputs, this degenerates to a "random spread" pattern.
+      return MakeSelectionVectorRandomSortedUnique(length, selected_length);
+    case SelectionPattern::kRandomSortedUnique:
+      return MakeSelectionVectorRandomSortedUnique(length, selected_length);
+  }
+  ARROW_LOG(FATAL) << "unreachable";
+  return nullptr;
+}
+
 }  // namespace
 
 void BenchmarkExec(benchmark::State& state, std::string spin_function,
-                   int64_t kernel_intensity, std::shared_ptr<Array> input,
+                   int64_t kernel_intensity, Datum input,
                    std::shared_ptr<SelectionVector> selection = nullptr) {
   static auto registered = RegisterSpinFunction();
   ARROW_CHECK_OK(registered);
 
   auto expr =
       call(std::move(spin_function), {field_ref(0)}, SpinOptions(kernel_intensity));
-  auto bound = expr.Bind(*schema({field("", input->type())})).ValueOrDie();
-  auto length = input->length();
-  auto batch = ExecBatch{{std::move(input)}, length, std::move(selection)};
+  auto bound = expr.Bind(*schema({field("", input.type())})).ValueOrDie();
+  auto length = input.length();
+  auto batch = ExecBatch(std::vector<Datum>{std::move(input)}, length, std::move(selection));
 
   for (auto _ : state) {
     ARROW_CHECK_OK(ExecuteScalarExpression(bound, batch).status());
@@ -148,7 +320,7 @@ static void BM_ExecBaseline(benchmark::State& state) {
   const int64_t num_rows = state.range(1);
 
   auto input = ConstantArrayGenerator::Int32(num_rows, 0);
-  BenchmarkExec(state, "spin", kernel_intensity, std::move(input));
+  BenchmarkExec(state, "spin", kernel_intensity, Datum(std::move(input)));
 }
 
 // Selective: Run the spin kernel with a selection vector, either sparsely or densely,
@@ -161,7 +333,31 @@ static void BM_ExecSelective(benchmark::State& state, std::string spin_function)
 
   auto input = ConstantArrayGenerator::Int32(num_rows, 0);
   auto selection =
-      MakeSelectionVectorTo(static_cast<int64_t>(num_rows * selectivity / 100));
+      MakeSelectionVectorPrefix(static_cast<int64_t>(num_rows * selectivity / 100));
+  BenchmarkExec(state, std::move(spin_function), kernel_intensity, Datum(std::move(input)),
+                std::move(selection));
+}
+
+static void BM_ExecBaselineChunked(benchmark::State& state) {
+  const int64_t kernel_intensity = state.range(0);
+  const int64_t num_rows = state.range(1);
+  const int64_t chunk_size = state.range(2);
+
+  auto input = MakeChunkedInt32(num_rows, chunk_size);
+  BenchmarkExec(state, "spin", kernel_intensity, Datum(std::move(input)));
+}
+
+static void BM_ExecSelectiveChunked(benchmark::State& state, std::string spin_function,
+                                   SelectionPattern pattern) {
+  const int64_t selectivity = state.range(0);
+  ARROW_CHECK(selectivity >= 0 && selectivity <= 100);
+  const int64_t kernel_intensity = state.range(1);
+  const int64_t num_rows = state.range(2);
+  const int64_t chunk_size = state.range(3);
+
+  Datum input(MakeChunkedInt32(num_rows, chunk_size));
+  const int64_t selected_length = static_cast<int64_t>(num_rows * selectivity / 100);
+  auto selection = MakeSelectionVector(pattern, input, selected_length);
   BenchmarkExec(state, std::move(spin_function), kernel_intensity, std::move(input),
                 std::move(selection));
 }
@@ -172,6 +368,11 @@ const char* kKernelIntensityArgName = "kernel_intensity";
 const std::vector<int64_t> kKernelIntensityArg = benchmark::CreateDenseRange(0, 100, 20);
 const char* kNumRowsArgName = "num_rows";
 const std::vector<int64_t> kNumRowsArg{4096};
+
+const char* kChunkSizeArgName = "chunk_size";
+const std::vector<int64_t> kChunkSizeArg{4096, 256, 16};
+const std::vector<int64_t> kSelectivityChunkedArg{0, 1, 20, 50, 100};
+const std::vector<int64_t> kKernelIntensityChunkedArg{0, 100};
 
 BENCHMARK(BM_ExecBaseline)
     ->ArgNames({kKernelIntensityArgName, kNumRowsArgName})
@@ -184,5 +385,50 @@ BENCHMARK_CAPTURE(BM_ExecSelective, sparse, "spin_selective")
 BENCHMARK_CAPTURE(BM_ExecSelective, dense, "spin")
     ->ArgNames({kSelectivityArgName, kKernelIntensityArgName, kNumRowsArgName})
     ->ArgsProduct({kSelectivityArg, kKernelIntensityArg, kNumRowsArg});
+
+BENCHMARK(BM_ExecBaselineChunked)
+    ->ArgNames({kKernelIntensityArgName, kNumRowsArgName, kChunkSizeArgName})
+    ->ArgsProduct({kKernelIntensityChunkedArg, kNumRowsArg, kChunkSizeArg});
+
+BENCHMARK_CAPTURE(BM_ExecSelectiveChunked, sparse_prefix, "spin_selective",
+                  SelectionPattern::kPrefix)
+    ->ArgNames(
+        {kSelectivityArgName, kKernelIntensityArgName, kNumRowsArgName, kChunkSizeArgName})
+    ->ArgsProduct(
+        {kSelectivityChunkedArg, kKernelIntensityChunkedArg, kNumRowsArg, kChunkSizeArg});
+
+BENCHMARK_CAPTURE(BM_ExecSelectiveChunked, sparse_one_per_chunk, "spin_selective",
+                  SelectionPattern::kOnePerChunk)
+    ->ArgNames(
+        {kSelectivityArgName, kKernelIntensityArgName, kNumRowsArgName, kChunkSizeArgName})
+    ->ArgsProduct(
+        {kSelectivityChunkedArg, kKernelIntensityChunkedArg, kNumRowsArg, kChunkSizeArg});
+
+BENCHMARK_CAPTURE(BM_ExecSelectiveChunked, sparse_random, "spin_selective",
+                  SelectionPattern::kRandomSortedUnique)
+    ->ArgNames(
+        {kSelectivityArgName, kKernelIntensityArgName, kNumRowsArgName, kChunkSizeArgName})
+    ->ArgsProduct(
+        {kSelectivityChunkedArg, kKernelIntensityChunkedArg, kNumRowsArg, kChunkSizeArg});
+
+BENCHMARK_CAPTURE(BM_ExecSelectiveChunked, dense_prefix, "spin", SelectionPattern::kPrefix)
+    ->ArgNames(
+        {kSelectivityArgName, kKernelIntensityArgName, kNumRowsArgName, kChunkSizeArgName})
+    ->ArgsProduct(
+        {kSelectivityChunkedArg, kKernelIntensityChunkedArg, kNumRowsArg, kChunkSizeArg});
+
+BENCHMARK_CAPTURE(BM_ExecSelectiveChunked, dense_one_per_chunk, "spin",
+                  SelectionPattern::kOnePerChunk)
+    ->ArgNames(
+        {kSelectivityArgName, kKernelIntensityArgName, kNumRowsArgName, kChunkSizeArgName})
+    ->ArgsProduct(
+        {kSelectivityChunkedArg, kKernelIntensityChunkedArg, kNumRowsArg, kChunkSizeArg});
+
+BENCHMARK_CAPTURE(BM_ExecSelectiveChunked, dense_random, "spin",
+                  SelectionPattern::kRandomSortedUnique)
+    ->ArgNames(
+        {kSelectivityArgName, kKernelIntensityArgName, kNumRowsArgName, kChunkSizeArgName})
+    ->ArgsProduct(
+        {kSelectivityChunkedArg, kKernelIntensityChunkedArg, kNumRowsArg, kChunkSizeArg});
 
 }  // namespace arrow::compute

--- a/cpp/src/arrow/compute/exec_benchmark.cc
+++ b/cpp/src/arrow/compute/exec_benchmark.cc
@@ -115,7 +115,7 @@ Status RegisterSpinFunction() {
 }
 
 std::shared_ptr<SelectionVector> MakeSelectionVectorTo(int64_t length) {
-  auto res = gen::Step<int32_t>()->Generate(length);
+  auto res = gen::Step<uint64_t>()->Generate(length);
   ARROW_CHECK_OK(res.status());
   auto arr = res.ValueUnsafe();
   return std::make_shared<SelectionVector>(*arr);

--- a/cpp/src/arrow/compute/exec_internal.h
+++ b/cpp/src/arrow/compute/exec_internal.h
@@ -174,31 +174,40 @@ Status PropagateNulls(KernelContext* ctx, const ExecSpan& batch, ArrayData* out)
 ARROW_EXPORT
 void PropagateNullsSpans(const ExecSpan& batch, ArraySpan* out);
 
+// Lambda helper & CTAD
+template <class... Ts>
+struct Overloaded : Ts... {
+  using Ts::operator()...;
+};
+template <class... Ts>
+Overloaded(Ts...)->Overloaded<Ts...>;
+
 template <typename OnSelectionFn>
 typename ::arrow::internal::call_traits::enable_if_return<OnSelectionFn, Status>::type
 VisitSelectionSpanInline(const SelectionSpan& selection, OnSelectionFn&& on_selection) {
   return std::visit(
-      [&](const auto& span) -> Status {
-        using SpanType = std::decay_t<decltype(span)>;
-        if constexpr (std::is_same_v<SpanType, ContiguousSpan>) {
-          for (int64_t i = 0; i < span.length; ++i) {
-            RETURN_NOT_OK(on_selection(span.start_offset + i));
-          }
-          return Status::OK();
-        } else if constexpr (std::is_same_v<SpanType, FilteredSpan>) {
-          DCHECK_NE(span.bitmap, nullptr);
-          for (int64_t i = 0; i < span.length; ++i) {
-            if (bit_util::GetBit(span.bitmap, span.bitmap_offset + i)) {
+      Overloaded{
+          [&](const ContiguousSpan& span) -> Status {
+            for (int64_t i = 0; i < span.length; ++i) {
               RETURN_NOT_OK(on_selection(span.start_offset + i));
             }
-          }
-          return Status::OK();
-        } else {
-          for (int64_t i = 0; i < span.length(); ++i) {
-            RETURN_NOT_OK(on_selection(span[i]));
-          }
-          return Status::OK();
-        }
+            return Status::OK();
+          },
+          [&](const FilteredSpan& span) -> Status {
+            DCHECK_NE(span.bitmap, nullptr);
+            for (int64_t i = 0; i < span.length; ++i) {
+              if (bit_util::GetBit(span.bitmap, span.bitmap_offset + i)) {
+                RETURN_NOT_OK(on_selection(span.start_offset + i));
+              }
+            }
+            return Status::OK();
+          },
+          [&](const DiscreteSpan& span) -> Status {
+            for (int64_t i = 0; i < span.length; ++i) {
+              RETURN_NOT_OK(on_selection(span[i]));
+            }
+            return Status::OK();
+          },
       },
       selection);
 }
@@ -207,24 +216,25 @@ template <typename OnSelectionFn>
 typename ::arrow::internal::call_traits::enable_if_return<OnSelectionFn, void>::type
 VisitSelectionSpanInline(const SelectionSpan& selection, OnSelectionFn&& on_selection) {
   std::visit(
-      [&](const auto& span) {
-        using SpanType = std::decay_t<decltype(span)>;
-        if constexpr (std::is_same_v<SpanType, ContiguousSpan>) {
-          for (int64_t i = 0; i < span.length; ++i) {
-            on_selection(span.start_offset + i);
-          }
-        } else if constexpr (std::is_same_v<SpanType, FilteredSpan>) {
-          DCHECK_NE(span.bitmap, nullptr);
-          for (int64_t i = 0; i < span.length; ++i) {
-            if (bit_util::GetBit(span.bitmap, span.bitmap_offset + i)) {
+      Overloaded{
+          [&](const ContiguousSpan& span) {
+            for (int64_t i = 0; i < span.length; ++i) {
               on_selection(span.start_offset + i);
             }
-          }
-        } else {
-          for (int64_t i = 0; i < span.length(); ++i) {
-            on_selection(span[i]);
-          }
-        }
+          },
+          [&](const FilteredSpan& span) {
+            DCHECK_NE(span.bitmap, nullptr);
+            for (int64_t i = 0; i < span.length; ++i) {
+              if (bit_util::GetBit(span.bitmap, span.bitmap_offset + i)) {
+                on_selection(span.start_offset + i);
+              }
+            }
+          },
+          [&](const DiscreteSpan& span) {
+            for (int64_t i = 0; i < span.length; ++i) {
+              on_selection(span[i]);
+            }
+          },
       },
       selection);
 }

--- a/cpp/src/arrow/compute/exec_internal.h
+++ b/cpp/src/arrow/compute/exec_internal.h
@@ -194,6 +194,9 @@ VisitSelectedIndicesInline(const ContiguousSpan& span, OnSelectionFn&& on_select
 template <typename OnSelectionFn>
 typename ::arrow::internal::call_traits::enable_if_return<OnSelectionFn, Status>::type
 VisitSelectedIndicesInline(const FilteredSpan& span, OnSelectionFn&& on_selection) {
+  if (span.length == 0) {
+    return Status::OK();
+  }
   DCHECK_NE(span.bitmap, nullptr);
   for (int64_t i = 0; i < span.length; ++i) {
     if (bit_util::GetBit(span.bitmap, span.bitmap_offset + i)) {
@@ -206,6 +209,9 @@ VisitSelectedIndicesInline(const FilteredSpan& span, OnSelectionFn&& on_selectio
 template <typename OnSelectionFn>
 typename ::arrow::internal::call_traits::enable_if_return<OnSelectionFn, void>::type
 VisitSelectedIndicesInline(const FilteredSpan& span, OnSelectionFn&& on_selection) {
+  if (span.length == 0) {
+    return;
+  }
   DCHECK_NE(span.bitmap, nullptr);
   for (int64_t i = 0; i < span.length; ++i) {
     if (bit_util::GetBit(span.bitmap, span.bitmap_offset + i)) {

--- a/cpp/src/arrow/compute/exec_internal.h
+++ b/cpp/src/arrow/compute/exec_internal.h
@@ -174,41 +174,68 @@ Status PropagateNulls(KernelContext* ctx, const ExecSpan& batch, ArrayData* out)
 ARROW_EXPORT
 void PropagateNullsSpans(const ExecSpan& batch, ArraySpan* out);
 
-// Lambda helper & CTAD
-template <class... Ts>
-struct Overloaded : Ts... {
-  using Ts::operator()...;
-};
-template <class... Ts>
-Overloaded(Ts...)->Overloaded<Ts...>;
+template <typename OnSelectionFn>
+typename ::arrow::internal::call_traits::enable_if_return<OnSelectionFn, Status>::type
+VisitSelectedIndicesInline(const ContiguousSpan& span, OnSelectionFn&& on_selection) {
+  for (int64_t i = 0; i < span.length; ++i) {
+    RETURN_NOT_OK(on_selection(span.start_offset + i));
+  }
+  return Status::OK();
+}
+
+template <typename OnSelectionFn>
+typename ::arrow::internal::call_traits::enable_if_return<OnSelectionFn, void>::type
+VisitSelectedIndicesInline(const ContiguousSpan& span, OnSelectionFn&& on_selection) {
+  for (int64_t i = 0; i < span.length; ++i) {
+    on_selection(span.start_offset + i);
+  }
+}
+
+template <typename OnSelectionFn>
+typename ::arrow::internal::call_traits::enable_if_return<OnSelectionFn, Status>::type
+VisitSelectedIndicesInline(const FilteredSpan& span, OnSelectionFn&& on_selection) {
+  DCHECK_NE(span.bitmap, nullptr);
+  for (int64_t i = 0; i < span.length; ++i) {
+    if (bit_util::GetBit(span.bitmap, span.bitmap_offset + i)) {
+      RETURN_NOT_OK(on_selection(span.start_offset + i));
+    }
+  }
+  return Status::OK();
+}
+
+template <typename OnSelectionFn>
+typename ::arrow::internal::call_traits::enable_if_return<OnSelectionFn, void>::type
+VisitSelectedIndicesInline(const FilteredSpan& span, OnSelectionFn&& on_selection) {
+  DCHECK_NE(span.bitmap, nullptr);
+  for (int64_t i = 0; i < span.length; ++i) {
+    if (bit_util::GetBit(span.bitmap, span.bitmap_offset + i)) {
+      on_selection(span.start_offset + i);
+    }
+  }
+}
+
+template <typename OnSelectionFn>
+typename ::arrow::internal::call_traits::enable_if_return<OnSelectionFn, Status>::type
+VisitSelectedIndicesInline(const DiscreteSpan& span, OnSelectionFn&& on_selection) {
+  for (int64_t i = 0; i < span.length; ++i) {
+    RETURN_NOT_OK(on_selection(span[i]));
+  }
+  return Status::OK();
+}
+
+template <typename OnSelectionFn>
+typename ::arrow::internal::call_traits::enable_if_return<OnSelectionFn, void>::type
+VisitSelectedIndicesInline(const DiscreteSpan& span, OnSelectionFn&& on_selection) {
+  for (int64_t i = 0; i < span.length; ++i) {
+    on_selection(span[i]);
+  }
+}
 
 template <typename OnSelectionFn>
 typename ::arrow::internal::call_traits::enable_if_return<OnSelectionFn, Status>::type
 VisitSelectionSpanInline(const SelectionSpan& selection, OnSelectionFn&& on_selection) {
   return std::visit(
-      Overloaded{
-          [&](const ContiguousSpan& span) -> Status {
-            for (int64_t i = 0; i < span.length; ++i) {
-              RETURN_NOT_OK(on_selection(span.start_offset + i));
-            }
-            return Status::OK();
-          },
-          [&](const FilteredSpan& span) -> Status {
-            DCHECK_NE(span.bitmap, nullptr);
-            for (int64_t i = 0; i < span.length; ++i) {
-              if (bit_util::GetBit(span.bitmap, span.bitmap_offset + i)) {
-                RETURN_NOT_OK(on_selection(span.start_offset + i));
-              }
-            }
-            return Status::OK();
-          },
-          [&](const DiscreteSpan& span) -> Status {
-            for (int64_t i = 0; i < span.length; ++i) {
-              RETURN_NOT_OK(on_selection(span[i]));
-            }
-            return Status::OK();
-          },
-      },
+      [&](const auto& span) -> Status { return VisitSelectedIndicesInline(span, on_selection); },
       selection);
 }
 
@@ -216,26 +243,7 @@ template <typename OnSelectionFn>
 typename ::arrow::internal::call_traits::enable_if_return<OnSelectionFn, void>::type
 VisitSelectionSpanInline(const SelectionSpan& selection, OnSelectionFn&& on_selection) {
   std::visit(
-      Overloaded{
-          [&](const ContiguousSpan& span) {
-            for (int64_t i = 0; i < span.length; ++i) {
-              on_selection(span.start_offset + i);
-            }
-          },
-          [&](const FilteredSpan& span) {
-            DCHECK_NE(span.bitmap, nullptr);
-            for (int64_t i = 0; i < span.length; ++i) {
-              if (bit_util::GetBit(span.bitmap, span.bitmap_offset + i)) {
-                on_selection(span.start_offset + i);
-              }
-            }
-          },
-          [&](const DiscreteSpan& span) {
-            for (int64_t i = 0; i < span.length; ++i) {
-              on_selection(span[i]);
-            }
-          },
-      },
+      [&](const auto& span) { VisitSelectedIndicesInline(span, on_selection); },
       selection);
 }
 

--- a/cpp/src/arrow/compute/exec_internal.h
+++ b/cpp/src/arrow/compute/exec_internal.h
@@ -194,9 +194,6 @@ VisitSelectedIndicesInline(const ContiguousSpan& span, OnSelectionFn&& on_select
 template <typename OnSelectionFn>
 typename ::arrow::internal::call_traits::enable_if_return<OnSelectionFn, Status>::type
 VisitSelectedIndicesInline(const FilteredSpan& span, OnSelectionFn&& on_selection) {
-  if (span.length == 0) {
-    return Status::OK();
-  }
   DCHECK_NE(span.bitmap, nullptr);
   for (int64_t i = 0; i < span.length; ++i) {
     if (bit_util::GetBit(span.bitmap, span.bitmap_offset + i)) {
@@ -209,9 +206,6 @@ VisitSelectedIndicesInline(const FilteredSpan& span, OnSelectionFn&& on_selectio
 template <typename OnSelectionFn>
 typename ::arrow::internal::call_traits::enable_if_return<OnSelectionFn, void>::type
 VisitSelectedIndicesInline(const FilteredSpan& span, OnSelectionFn&& on_selection) {
-  if (span.length == 0) {
-    return;
-  }
   DCHECK_NE(span.bitmap, nullptr);
   for (int64_t i = 0; i < span.length; ++i) {
     if (bit_util::GetBit(span.bitmap, span.bitmap_offset + i)) {

--- a/cpp/src/arrow/compute/exec_internal.h
+++ b/cpp/src/arrow/compute/exec_internal.h
@@ -21,6 +21,7 @@
 #include <limits>
 #include <memory>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 #include "arrow/array.h"
@@ -28,7 +29,9 @@
 #include "arrow/compute/exec.h"
 #include "arrow/compute/kernel.h"
 #include "arrow/status.h"
+#include "arrow/util/bit_util.h"
 #include "arrow/util/functional.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/visibility.h"
 
 namespace arrow {
@@ -65,7 +68,7 @@ class ARROW_EXPORT ExecSpanIterator {
   /// This function always populates at least one span. If you call this function with a
   /// blank ExecSpan after the first iteration, it will not work correctly (maybe we will
   /// change this later). Return false if the iteration is exhausted
-  bool Next(ExecSpan* span, SelectionVectorSpan* selection_span = NULLPTR);
+  bool Next(ExecSpan* span, SelectionSpan* selection_span = NULLPTR);
 
   int64_t length() const { return length_; }
   int64_t selection_length() const { return selection_length_; }
@@ -173,21 +176,57 @@ void PropagateNullsSpans(const ExecSpan& batch, ArraySpan* out);
 
 template <typename OnSelectionFn>
 typename ::arrow::internal::call_traits::enable_if_return<OnSelectionFn, Status>::type
-VisitSelectionVectorSpanInline(const SelectionVectorSpan& selection,
-                               OnSelectionFn&& on_selection) {
-  for (int64_t i = 0; i < selection.length(); ++i) {
-    RETURN_NOT_OK(on_selection(selection[i]));
-  }
-  return Status::OK();
+VisitSelectionSpanInline(const SelectionSpan& selection, OnSelectionFn&& on_selection) {
+  return std::visit(
+      [&](const auto& span) -> Status {
+        using SpanType = std::decay_t<decltype(span)>;
+        if constexpr (std::is_same_v<SpanType, ContiguousSpan>) {
+          for (int64_t i = 0; i < span.length; ++i) {
+            RETURN_NOT_OK(on_selection(span.start_offset + i));
+          }
+          return Status::OK();
+        } else if constexpr (std::is_same_v<SpanType, FilteredSpan>) {
+          DCHECK_NE(span.bitmap, nullptr);
+          for (int64_t i = 0; i < span.length; ++i) {
+            if (bit_util::GetBit(span.bitmap, span.bitmap_offset + i)) {
+              RETURN_NOT_OK(on_selection(span.start_offset + i));
+            }
+          }
+          return Status::OK();
+        } else {
+          for (int64_t i = 0; i < span.length(); ++i) {
+            RETURN_NOT_OK(on_selection(span[i]));
+          }
+          return Status::OK();
+        }
+      },
+      selection);
 }
 
 template <typename OnSelectionFn>
 typename ::arrow::internal::call_traits::enable_if_return<OnSelectionFn, void>::type
-VisitSelectionVectorSpanInline(const SelectionVectorSpan& selection,
-                               OnSelectionFn&& on_selection) {
-  for (int64_t i = 0; i < selection.length(); ++i) {
-    on_selection(selection[i]);
-  }
+VisitSelectionSpanInline(const SelectionSpan& selection, OnSelectionFn&& on_selection) {
+  std::visit(
+      [&](const auto& span) {
+        using SpanType = std::decay_t<decltype(span)>;
+        if constexpr (std::is_same_v<SpanType, ContiguousSpan>) {
+          for (int64_t i = 0; i < span.length; ++i) {
+            on_selection(span.start_offset + i);
+          }
+        } else if constexpr (std::is_same_v<SpanType, FilteredSpan>) {
+          DCHECK_NE(span.bitmap, nullptr);
+          for (int64_t i = 0; i < span.length; ++i) {
+            if (bit_util::GetBit(span.bitmap, span.bitmap_offset + i)) {
+              on_selection(span.start_offset + i);
+            }
+          }
+        } else {
+          for (int64_t i = 0; i < span.length(); ++i) {
+            on_selection(span[i]);
+          }
+        }
+      },
+      selection);
 }
 
 }  // namespace detail

--- a/cpp/src/arrow/compute/exec_test.cc
+++ b/cpp/src/arrow/compute/exec_test.cc
@@ -151,8 +151,11 @@ TEST(SelectionVector, Basics) {
   auto sel_vector = SelectionVectorFromJSON("[0, 42]");
 
   ASSERT_EQ(sel_vector->length(), 2);
-  ASSERT_EQ(sel_vector->indices()[0], 0);
-  ASSERT_EQ(sel_vector->indices()[1], 42);
+  ASSERT_OK_AND_ASSIGN(auto indices_data, sel_vector->ToIndicesArrayData());
+  const uint64_t* indices = indices_data->GetValues<uint64_t>(1);
+  ASSERT_NE(indices, nullptr);
+  ASSERT_EQ(indices[0], 0);
+  ASSERT_EQ(indices[1], 42);
 }
 
 TEST(SelectionVector, Validate) {
@@ -790,6 +793,13 @@ class TestExecSpanIterator : public TestComputeInternals {
                       const std::vector<int>& ex_batch_sizes,
                       const std::vector<int>& ex_selection_sizes) {
     SetupIterator(input, chunksize);
+    std::shared_ptr<ArrayData> selection_indices;
+    const uint64_t* selection_indices_values = nullptr;
+    if (input.selection_vector) {
+      ASSERT_OK_AND_ASSIGN(selection_indices, input.selection_vector->ToIndicesArrayData());
+      selection_indices_values = selection_indices->GetValues<uint64_t>(1);
+      ASSERT_NE(selection_indices_values, nullptr);
+    }
     ExecSpan batch;
     SelectionSpan selection;
     SelectionSpan* selection_ptr = nullptr;
@@ -837,7 +847,7 @@ class TestExecSpanIterator : public TestComputeInternals {
       if (iterator_.have_selection_vector()) {
         for (int64_t j = 0; j < selection_length; ++j) {
           ASSERT_EQ(static_cast<int64_t>(
-                        input.selection_vector->indices()[selection_position + j]) -
+                        selection_indices_values[selection_position + j]) -
                         position,
                     visited_indices[static_cast<size_t>(j)]);
           ASSERT_GE(visited_indices[static_cast<size_t>(j)], 0);
@@ -1085,32 +1095,32 @@ void AssertChunkedExecResultsEqualSparseWithSelection(int64_t exec_chunksize,
   ASSERT_EQ(Datum::CHUNKED_ARRAY, result.kind());
   const ChunkedArray& carr = *result.chunked_array();
   ASSERT_EQ(bit_util::CeilDiv(input.length(), exec_chunksize), carr.num_chunks());
-  int64_t selection_idx = 0;
+  int64_t selection_position = 0;
   for (int i = 0; i < carr.num_chunks(); ++i) {
-    const uint64_t chunk_end =
-        static_cast<uint64_t>(exec_chunksize) * static_cast<uint64_t>(i + 1);
-    auto next_selection_idx = selection_idx;
-    while (next_selection_idx < selection->length() &&
-           selection->indices()[next_selection_idx] < chunk_end) {
-      ++next_selection_idx;
-    }
-    DiscreteSpan selection_span{selection->indices() + selection_idx,
-                                next_selection_idx - selection_idx,
-                                static_cast<uint64_t>(exec_chunksize * i)};
-    selection_idx = next_selection_idx;
+    const uint64_t chunk_start = static_cast<uint64_t>(exec_chunksize) * i;
+    const uint64_t chunk_end = static_cast<uint64_t>(exec_chunksize) * (i + 1);
+    SelectionSpan selection_span;
+    selection_position += selection->GetSpanForChunk(chunk_start, chunk_end, selection_position,
+                                                     &selection_span);
     AssertArraysEqualSparseWithSelection(
         *input.Slice(exec_chunksize * i,
                      std::min(exec_chunksize, input.length() - exec_chunksize * i)),
         selection_span, *carr.chunk(i));
   }
+  ASSERT_EQ(selection_position, selection->length());
 }
 
 void AssertChunkedExecResultsEqualDenseWithSelection(int64_t exec_chunksize,
                                                      const Array& input,
                                                      const SelectionVector* selection,
                                                      const Datum& result) {
-  DiscreteSpan selection_span{selection->indices(), selection->length()};
-  if (selection_span.length <= exec_chunksize) {
+  SelectionSpan selection_span;
+  const uint64_t chunk_end = static_cast<uint64_t>(input.length());
+  const int64_t consumed = selection->GetSpanForChunk(/*chunk_start=*/0, chunk_end,
+                                                      /*selection_position=*/0,
+                                                      &selection_span);
+  ASSERT_EQ(consumed, selection->length());
+  if (selection->length() <= exec_chunksize) {
     ASSERT_EQ(Datum::ARRAY, result.kind());
     AssertArraysEqualDenseWithSelection(input, selection_span, *result.make_array());
   } else {
@@ -1841,7 +1851,11 @@ TEST_F(TestCallScalarFunctionPreallocationCases, BasicSelectiveSparse) {
     ASSERT_OK_AND_ASSIGN(auto test_copy,
                          ExpressionFunctionCaller::Maker(name, {uint8()}));
     for (const auto& selection : selections) {
-      DiscreteSpan selection_span{selection->indices(), selection->length()};
+      SelectionSpan selection_span;
+      const int64_t consumed = selection->GetSpanForChunk(
+          /*chunk_start=*/0, static_cast<uint64_t>(arr->length()),
+          /*selection_position=*/0, &selection_span);
+      ASSERT_EQ(consumed, selection->length());
       ResetContexts();
 
       DoTestBasic(test_copy.get(), *arr, selection, [&](const Datum& result) {
@@ -1860,7 +1874,11 @@ TEST_F(TestCallScalarFunctionPreallocationCases, BasicSelectiveDense) {
     ASSERT_OK_AND_ASSIGN(auto test_copy,
                          ExpressionFunctionCaller::Maker(name, {uint8()}));
     for (const auto& selection : selections) {
-      DiscreteSpan selection_span{selection->indices(), selection->length()};
+      SelectionSpan selection_span;
+      const int64_t consumed = selection->GetSpanForChunk(
+          /*chunk_start=*/0, static_cast<uint64_t>(arr->length()),
+          /*selection_position=*/0, &selection_span);
+      ASSERT_EQ(consumed, selection->length());
       ResetContexts();
 
       DoTestBasic(test_copy.get(), *arr, selection, [&](const Datum& result) {
@@ -1906,7 +1924,11 @@ TEST_F(TestCallScalarFunctionPreallocationCases, ChunkedSelectiveSparse) {
     ASSERT_OK_AND_ASSIGN(auto test_copy,
                          ExpressionFunctionCaller::Maker(name, {uint8()}));
     for (const auto& selection : selections) {
-      DiscreteSpan selection_span{selection->indices(), selection->length()};
+      SelectionSpan selection_span;
+      const int64_t consumed = selection->GetSpanForChunk(
+          /*chunk_start=*/0, static_cast<uint64_t>(arr->length()),
+          /*selection_position=*/0, &selection_span);
+      ASSERT_EQ(consumed, selection->length());
       ResetContexts();
 
       DoTestChunked(test_copy.get(), *carr, selection, [&](const Datum& result) {
@@ -1929,7 +1951,11 @@ TEST_F(TestCallScalarFunctionPreallocationCases, ChunkedSelectiveDense) {
     ASSERT_OK_AND_ASSIGN(auto test_copy,
                          ExpressionFunctionCaller::Maker(name, {uint8()}));
     for (const auto& selection : selections) {
-      DiscreteSpan selection_span{selection->indices(), selection->length()};
+      SelectionSpan selection_span;
+      const int64_t consumed = selection->GetSpanForChunk(
+          /*chunk_start=*/0, static_cast<uint64_t>(arr->length()),
+          /*selection_position=*/0, &selection_span);
+      ASSERT_EQ(consumed, selection->length());
       ResetContexts();
 
       DoTestChunked(test_copy.get(), *carr, selection, [&](const Datum& result) {
@@ -2075,7 +2101,11 @@ TEST_F(TestCallScalarFunctionBasicNonStandardCases, BasicSelectiveSparse) {
     ASSERT_OK_AND_ASSIGN(auto test_nopre,
                          ExpressionFunctionCaller::Maker(name, {uint8()}));
     for (const auto& selection : selections) {
-      DiscreteSpan selection_span{selection->indices(), selection->length()};
+      SelectionSpan selection_span;
+      const int64_t consumed = selection->GetSpanForChunk(
+          /*chunk_start=*/0, static_cast<uint64_t>(arr->length()),
+          /*selection_position=*/0, &selection_span);
+      ASSERT_EQ(consumed, selection->length());
       ResetContexts();
 
       DoTestBasic(test_nopre.get(), *arr, selection, [&](const Datum& result) {
@@ -2094,7 +2124,11 @@ TEST_F(TestCallScalarFunctionBasicNonStandardCases, BasicSelectiveDense) {
     ASSERT_OK_AND_ASSIGN(auto test_nopre,
                          ExpressionFunctionCaller::Maker(name, {uint8()}));
     for (const auto& selection : selections) {
-      DiscreteSpan selection_span{selection->indices(), selection->length()};
+      SelectionSpan selection_span;
+      const int64_t consumed = selection->GetSpanForChunk(
+          /*chunk_start=*/0, static_cast<uint64_t>(arr->length()),
+          /*selection_position=*/0, &selection_span);
+      ASSERT_EQ(consumed, selection->length());
       ResetContexts();
 
       DoTestBasic(test_nopre.get(), *arr, selection, [&](const Datum& result) {
@@ -2223,7 +2257,11 @@ TEST_F(TestCallScalarFunctionStatefulKernel, BasicSelectiveSparse) {
   ASSERT_OK_AND_ASSIGN(
       auto caller, ExpressionFunctionCaller::Maker("test_stateful_selective", {int32()}));
   for (const auto& selection : selections) {
-    DiscreteSpan selection_span{selection->indices(), selection->length()};
+    SelectionSpan selection_span;
+    const int64_t consumed = selection->GetSpanForChunk(
+        /*chunk_start=*/0, static_cast<uint64_t>(input->length()),
+        /*selection_position=*/0, &selection_span);
+    ASSERT_EQ(consumed, selection->length());
     ResetContexts();
 
     DoTestBasic(caller.get(), *input, multiplier, selection, [&](const Datum& result) {
@@ -2242,7 +2280,11 @@ TEST_F(TestCallScalarFunctionStatefulKernel, BasicSelectiveDense) {
   ASSERT_OK_AND_ASSIGN(auto caller,
                        ExpressionFunctionCaller::Maker("test_stateful", {int32()}));
   for (const auto& selection : selections) {
-    DiscreteSpan selection_span{selection->indices(), selection->length()};
+    SelectionSpan selection_span;
+    const int64_t consumed = selection->GetSpanForChunk(
+        /*chunk_start=*/0, static_cast<uint64_t>(input->length()),
+        /*selection_position=*/0, &selection_span);
+    ASSERT_EQ(consumed, selection->length());
     ResetContexts();
 
     DoTestBasic(caller.get(), *input, multiplier, selection, [&](const Datum& result) {

--- a/cpp/src/arrow/compute/exec_test.cc
+++ b/cpp/src/arrow/compute/exec_test.cc
@@ -189,137 +189,6 @@ TEST(SelectionVector, Validate) {
   }
 }
 
-TEST(SelectionVector, FromMask) {
-  {
-    auto mask = ArrayFromJSON(boolean(), "[true, null, false, true]");
-    ASSERT_OK_AND_ASSIGN(auto sel, SelectionVector::FromMask(*mask));
-    ASSERT_EQ(sel->length(), 2);
-    ASSERT_OK(sel->Validate(mask->length()));
-    ASSERT_OK_AND_ASSIGN(auto indices_data, sel->ToIndicesArrayData());
-    const uint64_t* indices = indices_data->GetValues<uint64_t>(1);
-    ASSERT_NE(indices, nullptr);
-    ASSERT_EQ(indices_data->length, 2);
-    ASSERT_EQ(indices[0], 0);
-    ASSERT_EQ(indices[1], 3);
-  }
-  {
-    // Ensure slice offsets are handled correctly.
-    auto base = ArrayFromJSON(boolean(), "[false, true, false, true]");
-    auto sliced = base->Slice(/*offset=*/1, /*length=*/2);  // [true, false]
-    ASSERT_OK_AND_ASSIGN(auto sel, SelectionVector::FromMask(*sliced));
-    ASSERT_EQ(sel->length(), 1);
-    ASSERT_OK(sel->Validate(sliced->length()));
-    ASSERT_OK_AND_ASSIGN(auto indices_data, sel->ToIndicesArrayData());
-    const uint64_t* indices = indices_data->GetValues<uint64_t>(1);
-    ASSERT_NE(indices, nullptr);
-    ASSERT_EQ(indices_data->length, 1);
-    ASSERT_EQ(indices[0], 0);
-  }
-}
-
-TEST(SelectionVector, FromRanges) {
-  const int64_t values_length = 10;
-  std::vector<SelectionRange> ranges = {SelectionRange{1, 2}, SelectionRange{5, 1}};
-  ASSERT_OK_AND_ASSIGN(auto sel, SelectionVector::FromRanges(ranges, values_length));
-  ASSERT_EQ(sel->length(), 3);
-  ASSERT_OK(sel->Validate(values_length));
-
-  ASSERT_OK_AND_ASSIGN(auto indices_data, sel->ToIndicesArrayData());
-  const uint64_t* indices = indices_data->GetValues<uint64_t>(1);
-  ASSERT_NE(indices, nullptr);
-  ASSERT_EQ(indices_data->length, 3);
-  ASSERT_EQ(indices[0], 1);
-  ASSERT_EQ(indices[1], 2);
-  ASSERT_EQ(indices[2], 5);
-
-  {
-    SelectionSpan span;
-    const int64_t consumed =
-        sel->GetSpanForChunk(/*chunk_start=*/0, /*chunk_end=*/4,
-                             /*selection_position=*/0, &span);
-    ASSERT_EQ(consumed, 2);
-    std::vector<int64_t> visited;
-    detail::VisitSelectionSpanInline(span, [&](int64_t i) { visited.push_back(i); });
-    ASSERT_EQ(visited, (std::vector<int64_t>{1, 2}));
-  }
-  {
-    SelectionSpan span;
-    const int64_t consumed =
-        sel->GetSpanForChunk(/*chunk_start=*/4, /*chunk_end=*/7,
-                             /*selection_position=*/2, &span);
-    ASSERT_EQ(consumed, 1);
-    std::vector<int64_t> visited;
-    detail::VisitSelectionSpanInline(span, [&](int64_t i) { visited.push_back(i); });
-    ASSERT_EQ(visited, (std::vector<int64_t>{1}));
-  }
-}
-
-Result<std::shared_ptr<SelectionVector>> SelectionVectorAsMask(
-    const SelectionVector& selection, int64_t values_length,
-    MemoryPool* pool = default_memory_pool()) {
-  if (pool == nullptr) {
-    pool = default_memory_pool();
-  }
-  if (values_length < 0) {
-    return Status::Invalid("values_length must be non-negative");
-  }
-  ARROW_ASSIGN_OR_RAISE(auto indices_data, selection.ToIndicesArrayData(pool));
-  ARROW_ASSIGN_OR_RAISE(auto bitmap, AllocateEmptyBitmap(values_length, pool));
-  uint8_t* bits = bitmap->mutable_data();
-  const uint64_t* indices = indices_data->GetValues<uint64_t>(1);
-  DCHECK(indices_data->length == 0 || indices != nullptr);
-  for (int64_t i = 0; i < indices_data->length; ++i) {
-    bit_util::SetBit(bits, static_cast<int64_t>(indices[i]));
-  }
-  auto mask_data =
-      ArrayData::Make(boolean(), values_length, {nullptr, std::move(bitmap)},
-                      /*null_count=*/0);
-  return SelectionVector::FromMask(*MakeArray(std::move(mask_data)), pool);
-}
-
-Result<std::shared_ptr<SelectionVector>> SelectionVectorAsRanges(
-    const SelectionVector& selection, int64_t values_length,
-    MemoryPool* pool = default_memory_pool()) {
-  if (pool == nullptr) {
-    pool = default_memory_pool();
-  }
-  if (values_length < 0) {
-    return Status::Invalid("values_length must be non-negative");
-  }
-  ARROW_ASSIGN_OR_RAISE(auto indices_data, selection.ToIndicesArrayData(pool));
-  const uint64_t* indices = indices_data->GetValues<uint64_t>(1);
-  DCHECK(indices_data->length == 0 || indices != nullptr);
-
-  std::vector<SelectionRange> ranges;
-  ranges.reserve(static_cast<size_t>(indices_data->length));
-  if (indices_data->length > 0) {
-    uint64_t start = indices[0];
-    uint64_t prev = indices[0];
-    for (int64_t i = 1; i < indices_data->length; ++i) {
-      const uint64_t cur = indices[i];
-      if (cur == prev + 1) {
-        prev = cur;
-        continue;
-      }
-      ranges.push_back(SelectionRange{start, prev - start + 1});
-      start = prev = cur;
-    }
-    ranges.push_back(SelectionRange{start, prev - start + 1});
-  }
-
-  return SelectionVector::FromRanges(std::move(ranges), values_length, pool);
-}
-
-template <typename Fn>
-void ForEachSelectionVectorBackend(const std::shared_ptr<SelectionVector>& base,
-                                   int64_t values_length, Fn&& fn) {
-  fn(base);
-  ASSERT_OK_AND_ASSIGN(auto mask, SelectionVectorAsMask(*base, values_length));
-  fn(mask);
-  ASSERT_OK_AND_ASSIGN(auto ranges, SelectionVectorAsRanges(*base, values_length));
-  fn(ranges);
-}
-
 TEST(DiscreteSpan, Basics) {
   auto indices = ArrayFromJSON(uint64(), "[0, 3, 7]");
   const uint64_t* idx = indices->data()->GetValues<uint64_t>(1);
@@ -1116,69 +985,11 @@ TEST_F(TestExecSpanIterator, SelectionSpanBasic) {
   CheckIteration(batch, /*chunksize=*/30, {30}, {4});
 }
 
-TEST_F(TestExecSpanIterator, SelectionSpanBasicMask) {
-  auto base_sel = SelectionVectorFromJSON("[1, 2, 7, 29]");
-  ASSERT_OK_AND_ASSIGN(auto sel, SelectionVectorAsMask(*base_sel, /*values_length=*/30));
-  ExecBatch batch(
-      {Datum(GetInt32Array(30)), Datum(GetInt32Array(30)),
-       Datum(std::make_shared<Int32Scalar>(5)), Datum(MakeNullScalar(boolean()))},
-      30, std::move(sel));
-
-  CheckIteration(batch, /*chunksize=*/7, {7, 7, 7, 7, 2}, {2, 1, 0, 0, 1});
-  CheckIteration(batch, /*chunksize=*/10, {10, 10, 10}, {3, 0, 1});
-  CheckIteration(batch, /*chunksize=*/20, {20, 10}, {3, 1});
-  CheckIteration(batch, /*chunksize=*/30, {30}, {4});
-}
-
-TEST_F(TestExecSpanIterator, SelectionSpanBasicRanges) {
-  auto base_sel = SelectionVectorFromJSON("[1, 2, 7, 29]");
-  ASSERT_OK_AND_ASSIGN(auto sel,
-                       SelectionVectorAsRanges(*base_sel, /*values_length=*/30));
-  ExecBatch batch(
-      {Datum(GetInt32Array(30)), Datum(GetInt32Array(30)),
-       Datum(std::make_shared<Int32Scalar>(5)), Datum(MakeNullScalar(boolean()))},
-      30, std::move(sel));
-
-  CheckIteration(batch, /*chunksize=*/7, {7, 7, 7, 7, 2}, {2, 1, 0, 0, 1});
-  CheckIteration(batch, /*chunksize=*/10, {10, 10, 10}, {3, 0, 1});
-  CheckIteration(batch, /*chunksize=*/20, {20, 10}, {3, 1});
-  CheckIteration(batch, /*chunksize=*/30, {30}, {4});
-}
-
 TEST_F(TestExecSpanIterator, SelectionSpanChunked) {
   ExecBatch batch({Datum(GetInt32Chunked({0, 20, 10})), Datum(GetInt32Chunked({15, 15})),
                    Datum(GetInt32Array(30)), Datum(std::make_shared<Int32Scalar>(5)),
                    Datum(MakeNullScalar(boolean()))},
                   30, SelectionVectorFromJSON("[1, 2, 7, 29]"));
-
-  CheckIteration(batch, /*chunksize=*/7, {7, 7, 1, 5, 7, 3}, {2, 1, 0, 0, 0, 1});
-  CheckIteration(batch, /*chunksize=*/10, {10, 5, 5, 10}, {3, 0, 0, 1});
-  CheckIteration(batch, /*chunksize=*/20, {15, 5, 10}, {3, 0, 1});
-  CheckIteration(batch, /*chunksize=*/30, {15, 5, 10}, {3, 0, 1});
-}
-
-TEST_F(TestExecSpanIterator, SelectionSpanChunkedMask) {
-  auto base_sel = SelectionVectorFromJSON("[1, 2, 7, 29]");
-  ASSERT_OK_AND_ASSIGN(auto sel, SelectionVectorAsMask(*base_sel, /*values_length=*/30));
-  ExecBatch batch({Datum(GetInt32Chunked({0, 20, 10})), Datum(GetInt32Chunked({15, 15})),
-                   Datum(GetInt32Array(30)), Datum(std::make_shared<Int32Scalar>(5)),
-                   Datum(MakeNullScalar(boolean()))},
-                  30, std::move(sel));
-
-  CheckIteration(batch, /*chunksize=*/7, {7, 7, 1, 5, 7, 3}, {2, 1, 0, 0, 0, 1});
-  CheckIteration(batch, /*chunksize=*/10, {10, 5, 5, 10}, {3, 0, 0, 1});
-  CheckIteration(batch, /*chunksize=*/20, {15, 5, 10}, {3, 0, 1});
-  CheckIteration(batch, /*chunksize=*/30, {15, 5, 10}, {3, 0, 1});
-}
-
-TEST_F(TestExecSpanIterator, SelectionSpanChunkedRanges) {
-  auto base_sel = SelectionVectorFromJSON("[1, 2, 7, 29]");
-  ASSERT_OK_AND_ASSIGN(auto sel,
-                       SelectionVectorAsRanges(*base_sel, /*values_length=*/30));
-  ExecBatch batch({Datum(GetInt32Chunked({0, 20, 10})), Datum(GetInt32Chunked({15, 15})),
-                   Datum(GetInt32Array(30)), Datum(std::make_shared<Int32Scalar>(5)),
-                   Datum(MakeNullScalar(boolean()))},
-                  30, std::move(sel));
 
   CheckIteration(batch, /*chunksize=*/7, {7, 7, 1, 5, 7, 3}, {2, 1, 0, 0, 0, 1});
   CheckIteration(batch, /*chunksize=*/10, {10, 5, 5, 10}, {3, 0, 0, 1});
@@ -1399,20 +1210,13 @@ Status ExecComputedBitmap(KernelContext* ctx, const ExecSpan& batch, ExecResult*
   // as the input bitmap
   const ArraySpan& arg0 = batch[0].array;
   ArraySpan* out_arr = out->array_span_mutable();
-  const uint8_t* src_validity = arg0.buffers[0].data;
-  if (src_validity == nullptr) {
-    // A null validity bitmap means "all valid".
-    bit_util::SetBitsTo(out_arr->buffers[0].data, out_arr->offset, batch.length, true);
-    return ExecCopyArraySpan(ctx, batch, out);
-  }
-
-  if (CountSetBits(src_validity, arg0.offset, batch.length) > 0) {
+  if (CountSetBits(arg0.buffers[0].data, arg0.offset, batch.length) > 0) {
     // Check that the bitmap has not been already copied over
-    DCHECK(!BitmapEquals(src_validity, arg0.offset, out_arr->buffers[0].data,
+    DCHECK(!BitmapEquals(arg0.buffers[0].data, arg0.offset, out_arr->buffers[0].data,
                          out_arr->offset, batch.length));
   }
 
-  CopyBitmap(src_validity, arg0.offset, batch.length, out_arr->buffers[0].data,
+  CopyBitmap(arg0.buffers[0].data, arg0.offset, batch.length, out_arr->buffers[0].data,
              out_arr->offset);
   return ExecCopyArraySpan(ctx, batch, out);
 }
@@ -1424,20 +1228,13 @@ Status SelectiveExecComputedBitmap(KernelContext* ctx, const ExecSpan& batch,
   // as the input bitmap
   const ArraySpan& arg0 = batch[0].array;
   ArraySpan* out_arr = out->array_span_mutable();
-  const uint8_t* src_validity = arg0.buffers[0].data;
-  if (src_validity == nullptr) {
-    // A null validity bitmap means "all valid".
-    bit_util::SetBitsTo(out_arr->buffers[0].data, out_arr->offset, batch.length, true);
-    return SelectiveExecCopyArraySpan(ctx, batch, selection, out);
-  }
-
-  if (CountSetBits(src_validity, arg0.offset, batch.length) > 0) {
+  if (CountSetBits(arg0.buffers[0].data, arg0.offset, batch.length) > 0) {
     // Check that the bitmap has not been already copied over
-    DCHECK(!BitmapEquals(src_validity, arg0.offset, out_arr->buffers[0].data,
+    DCHECK(!BitmapEquals(arg0.buffers[0].data, arg0.offset, out_arr->buffers[0].data,
                          out_arr->offset, batch.length));
   }
 
-  CopyBitmap(src_validity, arg0.offset, batch.length, out_arr->buffers[0].data,
+  CopyBitmap(arg0.buffers[0].data, arg0.offset, batch.length, out_arr->buffers[0].data,
              out_arr->offset);
   return SelectiveExecCopyArraySpan(ctx, batch, selection, out);
 }
@@ -2053,22 +1850,18 @@ TEST_F(TestCallScalarFunctionPreallocationCases, BasicSelectiveSparse) {
     ARROW_SCOPED_TRACE(name);
     ASSERT_OK_AND_ASSIGN(auto test_copy,
                          ExpressionFunctionCaller::Maker(name, {uint8()}));
-    for (const auto& base : selections) {
-      ForEachSelectionVectorBackend(
-          base, arr->length(), [&](const std::shared_ptr<SelectionVector>& selection) {
-            SelectionSpan selection_span;
-            const int64_t consumed = selection->GetSpanForChunk(
-                /*chunk_start=*/0, static_cast<uint64_t>(arr->length()),
-                /*selection_position=*/0, &selection_span);
-            ASSERT_EQ(consumed, selection->length());
-            ResetContexts();
+    for (const auto& selection : selections) {
+      SelectionSpan selection_span;
+      const int64_t consumed = selection->GetSpanForChunk(
+          /*chunk_start=*/0, static_cast<uint64_t>(arr->length()),
+          /*selection_position=*/0, &selection_span);
+      ASSERT_EQ(consumed, selection->length());
+      ResetContexts();
 
-            DoTestBasic(test_copy.get(), *arr, selection, [&](const Datum& result) {
-              ASSERT_EQ(Datum::ARRAY, result.kind());
-              AssertArraysEqualSparseWithSelection(*arr, selection_span,
-                                                   *result.make_array());
-            });
-          });
+      DoTestBasic(test_copy.get(), *arr, selection, [&](const Datum& result) {
+        ASSERT_EQ(Datum::ARRAY, result.kind());
+        AssertArraysEqualSparseWithSelection(*arr, selection_span, *result.make_array());
+      });
     }
   }
 }
@@ -2080,22 +1873,18 @@ TEST_F(TestCallScalarFunctionPreallocationCases, BasicSelectiveDense) {
     ARROW_SCOPED_TRACE(name);
     ASSERT_OK_AND_ASSIGN(auto test_copy,
                          ExpressionFunctionCaller::Maker(name, {uint8()}));
-    for (const auto& base : selections) {
-      ForEachSelectionVectorBackend(
-          base, arr->length(), [&](const std::shared_ptr<SelectionVector>& selection) {
-            SelectionSpan selection_span;
-            const int64_t consumed = selection->GetSpanForChunk(
-                /*chunk_start=*/0, static_cast<uint64_t>(arr->length()),
-                /*selection_position=*/0, &selection_span);
-            ASSERT_EQ(consumed, selection->length());
-            ResetContexts();
+    for (const auto& selection : selections) {
+      SelectionSpan selection_span;
+      const int64_t consumed = selection->GetSpanForChunk(
+          /*chunk_start=*/0, static_cast<uint64_t>(arr->length()),
+          /*selection_position=*/0, &selection_span);
+      ASSERT_EQ(consumed, selection->length());
+      ResetContexts();
 
-            DoTestBasic(test_copy.get(), *arr, selection, [&](const Datum& result) {
-              ASSERT_EQ(Datum::ARRAY, result.kind());
-              AssertArraysEqualDenseWithSelection(*arr, selection_span,
-                                                  *result.make_array());
-            });
-          });
+      DoTestBasic(test_copy.get(), *arr, selection, [&](const Datum& result) {
+        ASSERT_EQ(Datum::ARRAY, result.kind());
+        AssertArraysEqualDenseWithSelection(*arr, selection_span, *result.make_array());
+      });
     }
   }
 }
@@ -2134,24 +1923,20 @@ TEST_F(TestCallScalarFunctionPreallocationCases, ChunkedSelectiveSparse) {
     ARROW_SCOPED_TRACE(name);
     ASSERT_OK_AND_ASSIGN(auto test_copy,
                          ExpressionFunctionCaller::Maker(name, {uint8()}));
-    for (const auto& base : selections) {
-      ForEachSelectionVectorBackend(
-          base, arr->length(), [&](const std::shared_ptr<SelectionVector>& selection) {
-            SelectionSpan selection_span;
-            const int64_t consumed = selection->GetSpanForChunk(
-                /*chunk_start=*/0, static_cast<uint64_t>(arr->length()),
-                /*selection_position=*/0, &selection_span);
-            ASSERT_EQ(consumed, selection->length());
-            ResetContexts();
+    for (const auto& selection : selections) {
+      SelectionSpan selection_span;
+      const int64_t consumed = selection->GetSpanForChunk(
+          /*chunk_start=*/0, static_cast<uint64_t>(arr->length()),
+          /*selection_position=*/0, &selection_span);
+      ASSERT_EQ(consumed, selection->length());
+      ResetContexts();
 
-            DoTestChunked(test_copy.get(), *carr, selection, [&](const Datum& result) {
-              ASSERT_EQ(Datum::CHUNKED_ARRAY, result.kind());
-              std::shared_ptr<ChunkedArray> actual = result.chunked_array();
-              ASSERT_EQ(1, actual->num_chunks());
-              AssertArraysEqualSparseWithSelection(*arr, selection_span,
-                                                   *actual->chunk(0));
-            });
-          });
+      DoTestChunked(test_copy.get(), *carr, selection, [&](const Datum& result) {
+        ASSERT_EQ(Datum::CHUNKED_ARRAY, result.kind());
+        std::shared_ptr<ChunkedArray> actual = result.chunked_array();
+        ASSERT_EQ(1, actual->num_chunks());
+        AssertArraysEqualSparseWithSelection(*arr, selection_span, *actual->chunk(0));
+      });
     }
   }
 }
@@ -2165,24 +1950,20 @@ TEST_F(TestCallScalarFunctionPreallocationCases, ChunkedSelectiveDense) {
     ARROW_SCOPED_TRACE(name);
     ASSERT_OK_AND_ASSIGN(auto test_copy,
                          ExpressionFunctionCaller::Maker(name, {uint8()}));
-    for (const auto& base : selections) {
-      ForEachSelectionVectorBackend(
-          base, arr->length(), [&](const std::shared_ptr<SelectionVector>& selection) {
-            SelectionSpan selection_span;
-            const int64_t consumed = selection->GetSpanForChunk(
-                /*chunk_start=*/0, static_cast<uint64_t>(arr->length()),
-                /*selection_position=*/0, &selection_span);
-            ASSERT_EQ(consumed, selection->length());
-            ResetContexts();
+    for (const auto& selection : selections) {
+      SelectionSpan selection_span;
+      const int64_t consumed = selection->GetSpanForChunk(
+          /*chunk_start=*/0, static_cast<uint64_t>(arr->length()),
+          /*selection_position=*/0, &selection_span);
+      ASSERT_EQ(consumed, selection->length());
+      ResetContexts();
 
-            DoTestChunked(test_copy.get(), *carr, selection, [&](const Datum& result) {
-              ASSERT_EQ(Datum::CHUNKED_ARRAY, result.kind());
-              std::shared_ptr<ChunkedArray> actual = result.chunked_array();
-              ASSERT_EQ(1, actual->num_chunks());
-              AssertArraysEqualDenseWithSelection(*arr, selection_span,
-                                                  *actual->chunk(0));
-            });
-          });
+      DoTestChunked(test_copy.get(), *carr, selection, [&](const Datum& result) {
+        ASSERT_EQ(Datum::CHUNKED_ARRAY, result.kind());
+        std::shared_ptr<ChunkedArray> actual = result.chunked_array();
+        ASSERT_EQ(1, actual->num_chunks());
+        AssertArraysEqualDenseWithSelection(*arr, selection_span, *actual->chunk(0));
+      });
     }
   }
 }
@@ -2220,18 +2001,15 @@ TEST_F(TestCallScalarFunctionPreallocationCases, IndependentPreallocateSelective
     ARROW_SCOPED_TRACE(name);
     ASSERT_OK_AND_ASSIGN(auto test_copy,
                          ExpressionFunctionCaller::Maker(name, {uint8()}));
-    for (const auto& base : selections) {
-      ForEachSelectionVectorBackend(
-          base, arr->length(), [&](const std::shared_ptr<SelectionVector>& selection) {
-            const int64_t exec_chunksize = 40;
-            ResetContexts();
+    for (const auto& selection : selections) {
+      const int64_t exec_chunksize = 40;
+      ResetContexts();
 
-            DoTestIndependentPreallocate(
-                test_copy.get(), exec_chunksize, *arr, selection, [&](const Datum& result) {
-                  AssertChunkedExecResultsEqualSparseWithSelection(
-                      exec_chunksize, *arr, selection.get(), result);
-                });
-          });
+      DoTestIndependentPreallocate(test_copy.get(), exec_chunksize, *arr, selection,
+                                   [&](const Datum& result) {
+                                     AssertChunkedExecResultsEqualSparseWithSelection(
+                                         exec_chunksize, *arr, selection.get(), result);
+                                   });
     }
   }
 }
@@ -2243,18 +2021,15 @@ TEST_F(TestCallScalarFunctionPreallocationCases, IndependentPreallocateSelective
     ARROW_SCOPED_TRACE(name);
     ASSERT_OK_AND_ASSIGN(auto test_copy,
                          ExpressionFunctionCaller::Maker(name, {uint8()}));
-    for (const auto& base : selections) {
-      ForEachSelectionVectorBackend(
-          base, arr->length(), [&](const std::shared_ptr<SelectionVector>& selection) {
-            const int64_t exec_chunksize = 40;
-            ResetContexts();
+    for (const auto& selection : selections) {
+      const int64_t exec_chunksize = 40;
+      ResetContexts();
 
-            DoTestIndependentPreallocate(
-                test_copy.get(), exec_chunksize, *arr, selection, [&](const Datum& result) {
-                  AssertChunkedExecResultsEqualDenseWithSelection(
-                      exec_chunksize, *arr, selection.get(), result);
-                });
-          });
+      DoTestIndependentPreallocate(test_copy.get(), exec_chunksize, *arr, selection,
+                                   [&](const Datum& result) {
+                                     AssertChunkedExecResultsEqualDenseWithSelection(
+                                         exec_chunksize, *arr, selection.get(), result);
+                                   });
     }
   }
 }
@@ -2325,22 +2100,18 @@ TEST_F(TestCallScalarFunctionBasicNonStandardCases, BasicSelectiveSparse) {
     ARROW_SCOPED_TRACE(name);
     ASSERT_OK_AND_ASSIGN(auto test_nopre,
                          ExpressionFunctionCaller::Maker(name, {uint8()}));
-    for (const auto& base : selections) {
-      ForEachSelectionVectorBackend(
-          base, arr->length(), [&](const std::shared_ptr<SelectionVector>& selection) {
-            SelectionSpan selection_span;
-            const int64_t consumed = selection->GetSpanForChunk(
-                /*chunk_start=*/0, static_cast<uint64_t>(arr->length()),
-                /*selection_position=*/0, &selection_span);
-            ASSERT_EQ(consumed, selection->length());
-            ResetContexts();
+    for (const auto& selection : selections) {
+      SelectionSpan selection_span;
+      const int64_t consumed = selection->GetSpanForChunk(
+          /*chunk_start=*/0, static_cast<uint64_t>(arr->length()),
+          /*selection_position=*/0, &selection_span);
+      ASSERT_EQ(consumed, selection->length());
+      ResetContexts();
 
-            DoTestBasic(test_nopre.get(), *arr, selection, [&](const Datum& result) {
-              ASSERT_EQ(Datum::ARRAY, result.kind());
-              AssertArraysEqualSparseWithSelection(*arr, selection_span,
-                                                   *result.make_array());
-            });
-          });
+      DoTestBasic(test_nopre.get(), *arr, selection, [&](const Datum& result) {
+        ASSERT_EQ(Datum::ARRAY, result.kind());
+        AssertArraysEqualSparseWithSelection(*arr, selection_span, *result.make_array());
+      });
     }
   }
 }
@@ -2352,22 +2123,18 @@ TEST_F(TestCallScalarFunctionBasicNonStandardCases, BasicSelectiveDense) {
     ARROW_SCOPED_TRACE(name);
     ASSERT_OK_AND_ASSIGN(auto test_nopre,
                          ExpressionFunctionCaller::Maker(name, {uint8()}));
-    for (const auto& base : selections) {
-      ForEachSelectionVectorBackend(
-          base, arr->length(), [&](const std::shared_ptr<SelectionVector>& selection) {
-            SelectionSpan selection_span;
-            const int64_t consumed = selection->GetSpanForChunk(
-                /*chunk_start=*/0, static_cast<uint64_t>(arr->length()),
-                /*selection_position=*/0, &selection_span);
-            ASSERT_EQ(consumed, selection->length());
-            ResetContexts();
+    for (const auto& selection : selections) {
+      SelectionSpan selection_span;
+      const int64_t consumed = selection->GetSpanForChunk(
+          /*chunk_start=*/0, static_cast<uint64_t>(arr->length()),
+          /*selection_position=*/0, &selection_span);
+      ASSERT_EQ(consumed, selection->length());
+      ResetContexts();
 
-            DoTestBasic(test_nopre.get(), *arr, selection, [&](const Datum& result) {
-              ASSERT_EQ(Datum::ARRAY, result.kind());
-              AssertArraysEqualDenseWithSelection(*arr, selection_span,
-                                                  *result.make_array());
-            });
-          });
+      DoTestBasic(test_nopre.get(), *arr, selection, [&](const Datum& result) {
+        ASSERT_EQ(Datum::ARRAY, result.kind());
+        AssertArraysEqualDenseWithSelection(*arr, selection_span, *result.make_array());
+      });
     }
   }
 }
@@ -2404,18 +2171,15 @@ TEST_F(TestCallScalarFunctionBasicNonStandardCases, SplitExecutionSelectiveSpars
     ARROW_SCOPED_TRACE(name);
     ASSERT_OK_AND_ASSIGN(auto test_nopre,
                          ExpressionFunctionCaller::Maker(name, {uint8()}));
-    for (const auto& base : selections) {
-      ForEachSelectionVectorBackend(
-          base, arr->length(), [&](const std::shared_ptr<SelectionVector>& selection) {
-            const int64_t exec_chunksize = 400;
-            ResetContexts();
+    for (const auto& selection : selections) {
+      const int64_t exec_chunksize = 400;
+      ResetContexts();
 
-            DoTestSplitExecution(test_nopre.get(), exec_chunksize, *arr, selection,
-                                 [&](const Datum& result) {
-                                   AssertChunkedExecResultsEqualSparseWithSelection(
-                                       exec_chunksize, *arr, selection.get(), result);
-                                 });
-          });
+      DoTestSplitExecution(test_nopre.get(), exec_chunksize, *arr, selection,
+                           [&](const Datum& result) {
+                             AssertChunkedExecResultsEqualSparseWithSelection(
+                                 exec_chunksize, *arr, selection.get(), result);
+                           });
     }
   }
 }
@@ -2427,18 +2191,15 @@ TEST_F(TestCallScalarFunctionBasicNonStandardCases, SplitExecutionSelectiveDense
     ARROW_SCOPED_TRACE(name);
     ASSERT_OK_AND_ASSIGN(auto test_nopre,
                          ExpressionFunctionCaller::Maker(name, {uint8()}));
-    for (const auto& base : selections) {
-      ForEachSelectionVectorBackend(
-          base, arr->length(), [&](const std::shared_ptr<SelectionVector>& selection) {
-            const int64_t exec_chunksize = 400;
-            ResetContexts();
+    for (const auto& selection : selections) {
+      const int64_t exec_chunksize = 400;
+      ResetContexts();
 
-            DoTestSplitExecution(test_nopre.get(), exec_chunksize, *arr, selection,
-                                 [&](const Datum& result) {
-                                   AssertChunkedExecResultsEqualDenseWithSelection(
-                                       exec_chunksize, *arr, selection.get(), result);
-                                 });
-          });
+      DoTestSplitExecution(test_nopre.get(), exec_chunksize, *arr, selection,
+                           [&](const Datum& result) {
+                             AssertChunkedExecResultsEqualDenseWithSelection(
+                                 exec_chunksize, *arr, selection.get(), result);
+                           });
     }
   }
 }
@@ -2495,22 +2256,19 @@ TEST_F(TestCallScalarFunctionStatefulKernel, BasicSelectiveSparse) {
   auto expected = GetExpected();
   ASSERT_OK_AND_ASSIGN(
       auto caller, ExpressionFunctionCaller::Maker("test_stateful_selective", {int32()}));
-  for (const auto& base : selections) {
-    ForEachSelectionVectorBackend(
-        base, input->length(), [&](const std::shared_ptr<SelectionVector>& selection) {
-          SelectionSpan selection_span;
-          const int64_t consumed = selection->GetSpanForChunk(
-              /*chunk_start=*/0, static_cast<uint64_t>(input->length()),
-              /*selection_position=*/0, &selection_span);
-          ASSERT_EQ(consumed, selection->length());
-          ResetContexts();
+  for (const auto& selection : selections) {
+    SelectionSpan selection_span;
+    const int64_t consumed = selection->GetSpanForChunk(
+        /*chunk_start=*/0, static_cast<uint64_t>(input->length()),
+        /*selection_position=*/0, &selection_span);
+    ASSERT_EQ(consumed, selection->length());
+    ResetContexts();
 
-          DoTestBasic(caller.get(), *input, multiplier, selection, [&](const Datum& result) {
-            ASSERT_EQ(Datum::ARRAY, result.kind());
-            AssertArraysEqualSparseWithSelection(*expected, selection_span,
-                                                 *result.make_array());
-          });
-        });
+    DoTestBasic(caller.get(), *input, multiplier, selection, [&](const Datum& result) {
+      ASSERT_EQ(Datum::ARRAY, result.kind());
+      AssertArraysEqualSparseWithSelection(*expected, selection_span,
+                                           *result.make_array());
+    });
   }
 }
 
@@ -2521,22 +2279,19 @@ TEST_F(TestCallScalarFunctionStatefulKernel, BasicSelectiveDense) {
   auto expected = GetExpected();
   ASSERT_OK_AND_ASSIGN(auto caller,
                        ExpressionFunctionCaller::Maker("test_stateful", {int32()}));
-  for (const auto& base : selections) {
-    ForEachSelectionVectorBackend(
-        base, input->length(), [&](const std::shared_ptr<SelectionVector>& selection) {
-          SelectionSpan selection_span;
-          const int64_t consumed = selection->GetSpanForChunk(
-              /*chunk_start=*/0, static_cast<uint64_t>(input->length()),
-              /*selection_position=*/0, &selection_span);
-          ASSERT_EQ(consumed, selection->length());
-          ResetContexts();
+  for (const auto& selection : selections) {
+    SelectionSpan selection_span;
+    const int64_t consumed = selection->GetSpanForChunk(
+        /*chunk_start=*/0, static_cast<uint64_t>(input->length()),
+        /*selection_position=*/0, &selection_span);
+    ASSERT_EQ(consumed, selection->length());
+    ResetContexts();
 
-          DoTestBasic(caller.get(), *input, multiplier, selection, [&](const Datum& result) {
-            ASSERT_EQ(Datum::ARRAY, result.kind());
-            AssertArraysEqualDenseWithSelection(*expected, selection_span,
-                                                *result.make_array());
-          });
-        });
+    DoTestBasic(caller.get(), *input, multiplier, selection, [&](const Datum& result) {
+      ASSERT_EQ(Datum::ARRAY, result.kind());
+      AssertArraysEqualDenseWithSelection(*expected, selection_span,
+                                          *result.make_array());
+    });
   }
 }
 

--- a/cpp/src/arrow/compute/exec_test.cc
+++ b/cpp/src/arrow/compute/exec_test.cc
@@ -792,14 +792,25 @@ class TestExecSpanIterator : public TestComputeInternals {
                       const std::vector<int>& ex_selection_sizes) {
     SetupIterator(input, chunksize);
     ExecSpan batch;
-    SelectionVectorSpan selection;
+    SelectionSpan selection;
+    SelectionSpan* selection_ptr = nullptr;
+    if (iterator_.have_selection_vector()) {
+      selection_ptr = &selection;
+    }
     int64_t position = 0, selection_position = 0;
     for (size_t i = 0; i < ex_batch_sizes.size(); ++i) {
       ASSERT_EQ(position, iterator_.position());
       ASSERT_EQ(selection_position, iterator_.selection_position());
-      ASSERT_TRUE(iterator_.Next(&batch, &selection));
+      ASSERT_TRUE(iterator_.Next(&batch, selection_ptr));
       ASSERT_EQ(ex_batch_sizes[i], batch.length);
-      ASSERT_EQ(ex_selection_sizes[i], selection.length());
+      const DiscreteSpan* discrete = nullptr;
+      int64_t selection_length = 0;
+      if (selection_ptr) {
+        discrete = std::get_if<DiscreteSpan>(&selection);
+        ASSERT_NE(discrete, nullptr);
+        selection_length = discrete->length();
+      }
+      ASSERT_EQ(ex_selection_sizes[i], selection_length);
 
       for (size_t j = 0; j < input.values.size(); ++j) {
         switch (input[j].kind()) {
@@ -826,20 +837,20 @@ class TestExecSpanIterator : public TestComputeInternals {
         }
       }
       if (iterator_.have_selection_vector()) {
-        for (int64_t j = 0; j < selection.length(); ++j) {
+        for (int64_t j = 0; j < discrete->length(); ++j) {
           ASSERT_EQ(static_cast<int64_t>(
                         input.selection_vector->indices()[selection_position + j]) -
                         position,
-                    selection[j]);
-          ASSERT_GE(selection[j], 0);
-          ASSERT_LT(selection[j], batch.length);
+                    (*discrete)[j]);
+          ASSERT_GE((*discrete)[j], 0);
+          ASSERT_LT((*discrete)[j], batch.length);
         }
       }
       position += ex_batch_sizes[i];
       selection_position += ex_selection_sizes[i];
     }
     // Ensure that the iterator is exhausted
-    ASSERT_FALSE(iterator_.Next(&batch, &selection));
+    ASSERT_FALSE(iterator_.Next(&batch, selection_ptr));
 
     ASSERT_EQ(iterator_.length(), iterator_.position());
     ASSERT_EQ(iterator_.selection_length(), iterator_.selection_position());
@@ -982,14 +993,18 @@ TEST_F(TestExecSpanIterator, SelectionSpanChunked) {
 // Scalar function execution
 
 template <typename OnSelectedFn, typename OnNonSelectedFn>
-void VisitIndicesWithSelection(int64_t length, const SelectionVectorSpan& selection,
+void VisitIndicesWithSelection(int64_t length, const SelectionSpan& selection,
                                OnSelectedFn&& on_selected,
                                OnNonSelectedFn&& on_non_selected) {
-  int64_t selected = 0;
+  std::vector<uint8_t> is_selected(static_cast<size_t>(length), 0);
+  detail::VisitSelectionSpanInline(selection, [&](int64_t i) {
+    ASSERT_GE(i, 0);
+    ASSERT_LT(i, length);
+    is_selected[static_cast<size_t>(i)] = 1;
+  });
   for (int64_t i = 0; i < length; ++i) {
-    if (selected < selection.length() && i == selection[selected]) {
+    if (is_selected[static_cast<size_t>(i)]) {
       on_selected(i);
-      ++selected;
     } else {
       on_non_selected(i);
     }
@@ -999,7 +1014,7 @@ void VisitIndicesWithSelection(int64_t length, const SelectionVectorSpan& select
 constexpr uint8_t kNonSelectedByte = 0xFE;
 
 void AssertArraysEqualSparseWithSelection(const Array& src,
-                                          const SelectionVectorSpan& selection,
+                                          const SelectionSpan& selection,
                                           const Array& dst) {
   ASSERT_EQ(src.length(), dst.length());
   ASSERT_EQ(src.type()->id(), dst.type()->id());
@@ -1034,7 +1049,7 @@ void AssertArraysEqualSparseWithSelection(const Array& src,
 }
 
 void AssertArraysEqualDenseWithSelection(const Array& src,
-                                         const SelectionVectorSpan& selection,
+                                         const SelectionSpan& selection,
                                          const Array& dst) {
   ASSERT_EQ(src.length(), dst.length());
   ASSERT_EQ(src.type()->id(), dst.type()->id());
@@ -1075,13 +1090,15 @@ void AssertChunkedExecResultsEqualSparseWithSelection(int64_t exec_chunksize,
   ASSERT_EQ(bit_util::CeilDiv(input.length(), exec_chunksize), carr.num_chunks());
   int64_t selection_idx = 0;
   for (int i = 0; i < carr.num_chunks(); ++i) {
+    const uint64_t chunk_end =
+        static_cast<uint64_t>(exec_chunksize) * static_cast<uint64_t>(i + 1);
     auto next_selection_idx = selection_idx;
     while (next_selection_idx < selection->length() &&
-           selection->indices()[next_selection_idx] < exec_chunksize * (i + 1)) {
+           selection->indices()[next_selection_idx] < chunk_end) {
       ++next_selection_idx;
     }
     selection_span.SetSlice(selection_idx, next_selection_idx - selection_idx,
-                            static_cast<int32_t>(exec_chunksize * i));
+                            static_cast<uint64_t>(exec_chunksize * i));
     selection_idx = next_selection_idx;
     AssertArraysEqualSparseWithSelection(
         *input.Slice(exec_chunksize * i,
@@ -1119,7 +1136,7 @@ Status ExecCopyArrayData(KernelContext*, const ExecSpan& batch, ExecResult* out)
 }
 
 Status SelectiveExecCopyArrayData(KernelContext* ctx, const ExecSpan& batch,
-                                  const SelectionVectorSpan& selection, ExecResult* out) {
+                                  const SelectionSpan& selection, ExecResult* out) {
   DCHECK_EQ(1, batch.num_values());
   int value_size = batch[0].type()->byte_width();
 
@@ -1156,7 +1173,7 @@ Status ExecCopyArraySpan(KernelContext*, const ExecSpan& batch, ExecResult* out)
 }
 
 Status SelectiveExecCopyArraySpan(KernelContext* ctx, const ExecSpan& batch,
-                                  const SelectionVectorSpan& selection, ExecResult* out) {
+                                  const SelectionSpan& selection, ExecResult* out) {
   DCHECK_EQ(1, batch.num_values());
   int value_size = batch[0].type()->byte_width();
   const ArraySpan& arg0 = batch[0].array;
@@ -1197,7 +1214,7 @@ Status ExecComputedBitmap(KernelContext* ctx, const ExecSpan& batch, ExecResult*
 }
 
 Status SelectiveExecComputedBitmap(KernelContext* ctx, const ExecSpan& batch,
-                                   const SelectionVectorSpan& selection,
+                                   const SelectionSpan& selection,
                                    ExecResult* out) {
   // Propagate nulls not used. Check that the out bitmap isn't the same already
   // as the input bitmap
@@ -1226,7 +1243,7 @@ Status ExecNoPreallocatedData(KernelContext* ctx, const ExecSpan& batch,
 }
 
 Status SelectiveExecNoPreallocatedData(KernelContext* ctx, const ExecSpan& batch,
-                                       const SelectionVectorSpan& selection,
+                                       const SelectionSpan& selection,
                                        ExecResult* out) {
   // Validity preallocated, but not the data
   ArrayData* out_arr = out->array_data().get();
@@ -1253,7 +1270,7 @@ Status ExecNoPreallocatedAnything(KernelContext* ctx, const ExecSpan& batch,
 }
 
 Status SelectiveExecNoPreallocatedAnything(KernelContext* ctx, const ExecSpan& batch,
-                                           const SelectionVectorSpan& selection,
+                                           const SelectionSpan& selection,
                                            ExecResult* out) {
   // Neither validity nor data preallocated
   ArrayData* out_arr = out->array_data().get();
@@ -1323,7 +1340,7 @@ Status ExecStateful(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) 
 }
 
 Status SelectiveExecStateful(KernelContext* ctx, const ExecSpan& batch,
-                             const SelectionVectorSpan& selection, ExecResult* out) {
+                             const SelectionSpan& selection, ExecResult* out) {
   // We take the value from the state and multiply the data in batch[0] with it
   ExampleState* state = static_cast<ExampleState*>(ctx->state());
   int32_t multiplier = checked_cast<const Int32Scalar&>(*state->value).value;
@@ -1360,7 +1377,7 @@ Status ExecAddInt32(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) 
 }
 
 Status SelectiveExecAddInt32(KernelContext* ctx, const ExecSpan& batch,
-                             const SelectionVectorSpan& selection, ExecResult* out) {
+                             const SelectionSpan& selection, ExecResult* out) {
   const int32_t* left_data = batch[0].array.GetValues<int32_t>(1);
   const int32_t* right_data = batch[1].array.GetValues<int32_t>(1);
   ArraySpan* out_arr = out->array_span_mutable();

--- a/cpp/src/arrow/compute/exec_test.cc
+++ b/cpp/src/arrow/compute/exec_test.cc
@@ -1048,11 +1048,8 @@ void AssertArraysEqualSparseWithSelection(const Array& src,
         }
       },
       [&](int64_t i) {
-        // Non-selected values should be the valid special value in the output
-        ASSERT_TRUE(bit_util::GetBit(dst_validity, dst_offset + i));
-        for (int j = 0; j < value_size; ++j) {
-          ASSERT_EQ(dst_data[(dst_offset + i) * value_size + j], kNonSelectedByte);
-        }
+        // Non-selected values should be invalid (null) in the output.
+        ASSERT_FALSE(bit_util::GetBit(dst_validity, dst_offset + i));
       });
 }
 
@@ -1092,21 +1089,35 @@ void AssertChunkedExecResultsEqualSparseWithSelection(int64_t exec_chunksize,
                                                       const Array& input,
                                                       const SelectionVector* selection,
                                                       const Datum& result) {
+  ARROW_UNUSED(exec_chunksize);
+  if (result.kind() == Datum::ARRAY) {
+    SelectionSpan selection_span;
+    const uint64_t chunk_end = static_cast<uint64_t>(input.length());
+    const int64_t consumed = selection->GetSpanForChunk(/*chunk_start=*/0, chunk_end,
+                                                        /*selection_position=*/0,
+                                                        &selection_span);
+    ASSERT_EQ(consumed, selection->length());
+    AssertArraysEqualSparseWithSelection(input, selection_span, *result.make_array());
+    return;
+  }
+
   ASSERT_EQ(Datum::CHUNKED_ARRAY, result.kind());
   const ChunkedArray& carr = *result.chunked_array();
-  ASSERT_EQ(bit_util::CeilDiv(input.length(), exec_chunksize), carr.num_chunks());
+  ASSERT_EQ(input.length(), carr.length());
   int64_t selection_position = 0;
+  int64_t input_offset = 0;
   for (int i = 0; i < carr.num_chunks(); ++i) {
-    const uint64_t chunk_start = static_cast<uint64_t>(exec_chunksize) * i;
-    const uint64_t chunk_end = static_cast<uint64_t>(exec_chunksize) * (i + 1);
+    const int64_t chunk_len = carr.chunk(i)->length();
+    const uint64_t chunk_start = static_cast<uint64_t>(input_offset);
+    const uint64_t chunk_end = static_cast<uint64_t>(input_offset + chunk_len);
     SelectionSpan selection_span;
     selection_position += selection->GetSpanForChunk(chunk_start, chunk_end, selection_position,
                                                      &selection_span);
-    AssertArraysEqualSparseWithSelection(
-        *input.Slice(exec_chunksize * i,
-                     std::min(exec_chunksize, input.length() - exec_chunksize * i)),
-        selection_span, *carr.chunk(i));
+    AssertArraysEqualSparseWithSelection(*input.Slice(input_offset, chunk_len), selection_span,
+                                         *carr.chunk(i));
+    input_offset += chunk_len;
   }
+  ASSERT_EQ(input_offset, input.length());
   ASSERT_EQ(selection_position, selection->length());
 }
 

--- a/cpp/src/arrow/compute/exec_test.cc
+++ b/cpp/src/arrow/compute/exec_test.cc
@@ -186,22 +186,21 @@ TEST(SelectionVector, Validate) {
   }
 }
 
-TEST(SelectionVectorSpan, Basics) {
+TEST(DiscreteSpan, Basics) {
   auto indices = ArrayFromJSON(uint64(), "[0, 3, 7]");
-  SelectionVectorSpan sel_span(indices->data()->GetValues<uint64_t>(1),
-                               indices->length() - 1,
-                               /*offset=*/1, /*index_back_shift=*/1);
+  const uint64_t* idx = indices->data()->GetValues<uint64_t>(1);
+  DiscreteSpan sel_span{idx + 1, /*length=*/2, /*index_back_shift=*/1};
   ASSERT_EQ(sel_span[0], 2);
   ASSERT_EQ(sel_span[1], 6);
 
-  sel_span.SetSlice(/*offset=*/1, /*length=*/2, /*index_back_shift=*/0);
-  ASSERT_EQ(sel_span[0], 3);
-  ASSERT_EQ(sel_span[1], 7);
+  DiscreteSpan sel_span2{idx + 1, /*length=*/2, /*index_back_shift=*/0};
+  ASSERT_EQ(sel_span2[0], 3);
+  ASSERT_EQ(sel_span2[1], 7);
 
-  sel_span.SetSlice(/*offset=*/0, /*length=*/3);
-  ASSERT_EQ(sel_span[0], 0);
-  ASSERT_EQ(sel_span[1], 3);
-  ASSERT_EQ(sel_span[2], 7);
+  DiscreteSpan sel_span3{idx, /*length=*/3, /*index_back_shift=*/0};
+  ASSERT_EQ(sel_span3[0], 0);
+  ASSERT_EQ(sel_span3[1], 3);
+  ASSERT_EQ(sel_span3[2], 7);
 }
 
 void AssertValidityZeroExtraBits(const uint8_t* data, int64_t length, int64_t offset) {
@@ -803,13 +802,12 @@ class TestExecSpanIterator : public TestComputeInternals {
       ASSERT_EQ(selection_position, iterator_.selection_position());
       ASSERT_TRUE(iterator_.Next(&batch, selection_ptr));
       ASSERT_EQ(ex_batch_sizes[i], batch.length);
-      const DiscreteSpan* discrete = nullptr;
-      int64_t selection_length = 0;
+      std::vector<int64_t> visited_indices;
       if (selection_ptr) {
-        discrete = std::get_if<DiscreteSpan>(&selection);
-        ASSERT_NE(discrete, nullptr);
-        selection_length = discrete->length();
+        detail::VisitSelectionSpanInline(selection,
+                                         [&](int64_t i) { visited_indices.push_back(i); });
       }
+      const int64_t selection_length = static_cast<int64_t>(visited_indices.size());
       ASSERT_EQ(ex_selection_sizes[i], selection_length);
 
       for (size_t j = 0; j < input.values.size(); ++j) {
@@ -837,13 +835,13 @@ class TestExecSpanIterator : public TestComputeInternals {
         }
       }
       if (iterator_.have_selection_vector()) {
-        for (int64_t j = 0; j < discrete->length(); ++j) {
+        for (int64_t j = 0; j < selection_length; ++j) {
           ASSERT_EQ(static_cast<int64_t>(
                         input.selection_vector->indices()[selection_position + j]) -
                         position,
-                    (*discrete)[j]);
-          ASSERT_GE((*discrete)[j], 0);
-          ASSERT_LT((*discrete)[j], batch.length);
+                    visited_indices[static_cast<size_t>(j)]);
+          ASSERT_GE(visited_indices[static_cast<size_t>(j)], 0);
+          ASSERT_LT(visited_indices[static_cast<size_t>(j)], batch.length);
         }
       }
       position += ex_batch_sizes[i];
@@ -1086,7 +1084,6 @@ void AssertChunkedExecResultsEqualSparseWithSelection(int64_t exec_chunksize,
                                                       const Datum& result) {
   ASSERT_EQ(Datum::CHUNKED_ARRAY, result.kind());
   const ChunkedArray& carr = *result.chunked_array();
-  SelectionVectorSpan selection_span(selection->indices(), selection->length());
   ASSERT_EQ(bit_util::CeilDiv(input.length(), exec_chunksize), carr.num_chunks());
   int64_t selection_idx = 0;
   for (int i = 0; i < carr.num_chunks(); ++i) {
@@ -1097,8 +1094,9 @@ void AssertChunkedExecResultsEqualSparseWithSelection(int64_t exec_chunksize,
            selection->indices()[next_selection_idx] < chunk_end) {
       ++next_selection_idx;
     }
-    selection_span.SetSlice(selection_idx, next_selection_idx - selection_idx,
-                            static_cast<uint64_t>(exec_chunksize * i));
+    DiscreteSpan selection_span{selection->indices() + selection_idx,
+                                next_selection_idx - selection_idx,
+                                static_cast<uint64_t>(exec_chunksize * i)};
     selection_idx = next_selection_idx;
     AssertArraysEqualSparseWithSelection(
         *input.Slice(exec_chunksize * i,
@@ -1111,8 +1109,8 @@ void AssertChunkedExecResultsEqualDenseWithSelection(int64_t exec_chunksize,
                                                      const Array& input,
                                                      const SelectionVector* selection,
                                                      const Datum& result) {
-  SelectionVectorSpan selection_span(selection->indices(), selection->length());
-  if (selection_span.length() <= exec_chunksize) {
+  DiscreteSpan selection_span{selection->indices(), selection->length()};
+  if (selection_span.length <= exec_chunksize) {
     ASSERT_EQ(Datum::ARRAY, result.kind());
     AssertArraysEqualDenseWithSelection(input, selection_span, *result.make_array());
   } else {
@@ -1843,7 +1841,7 @@ TEST_F(TestCallScalarFunctionPreallocationCases, BasicSelectiveSparse) {
     ASSERT_OK_AND_ASSIGN(auto test_copy,
                          ExpressionFunctionCaller::Maker(name, {uint8()}));
     for (const auto& selection : selections) {
-      SelectionVectorSpan selection_span(selection->indices(), selection->length());
+      DiscreteSpan selection_span{selection->indices(), selection->length()};
       ResetContexts();
 
       DoTestBasic(test_copy.get(), *arr, selection, [&](const Datum& result) {
@@ -1862,7 +1860,7 @@ TEST_F(TestCallScalarFunctionPreallocationCases, BasicSelectiveDense) {
     ASSERT_OK_AND_ASSIGN(auto test_copy,
                          ExpressionFunctionCaller::Maker(name, {uint8()}));
     for (const auto& selection : selections) {
-      SelectionVectorSpan selection_span(selection->indices(), selection->length());
+      DiscreteSpan selection_span{selection->indices(), selection->length()};
       ResetContexts();
 
       DoTestBasic(test_copy.get(), *arr, selection, [&](const Datum& result) {
@@ -1908,7 +1906,7 @@ TEST_F(TestCallScalarFunctionPreallocationCases, ChunkedSelectiveSparse) {
     ASSERT_OK_AND_ASSIGN(auto test_copy,
                          ExpressionFunctionCaller::Maker(name, {uint8()}));
     for (const auto& selection : selections) {
-      SelectionVectorSpan selection_span(selection->indices(), selection->length());
+      DiscreteSpan selection_span{selection->indices(), selection->length()};
       ResetContexts();
 
       DoTestChunked(test_copy.get(), *carr, selection, [&](const Datum& result) {
@@ -1931,7 +1929,7 @@ TEST_F(TestCallScalarFunctionPreallocationCases, ChunkedSelectiveDense) {
     ASSERT_OK_AND_ASSIGN(auto test_copy,
                          ExpressionFunctionCaller::Maker(name, {uint8()}));
     for (const auto& selection : selections) {
-      SelectionVectorSpan selection_span(selection->indices(), selection->length());
+      DiscreteSpan selection_span{selection->indices(), selection->length()};
       ResetContexts();
 
       DoTestChunked(test_copy.get(), *carr, selection, [&](const Datum& result) {
@@ -2077,7 +2075,7 @@ TEST_F(TestCallScalarFunctionBasicNonStandardCases, BasicSelectiveSparse) {
     ASSERT_OK_AND_ASSIGN(auto test_nopre,
                          ExpressionFunctionCaller::Maker(name, {uint8()}));
     for (const auto& selection : selections) {
-      SelectionVectorSpan selection_span(selection->indices(), selection->length());
+      DiscreteSpan selection_span{selection->indices(), selection->length()};
       ResetContexts();
 
       DoTestBasic(test_nopre.get(), *arr, selection, [&](const Datum& result) {
@@ -2096,7 +2094,7 @@ TEST_F(TestCallScalarFunctionBasicNonStandardCases, BasicSelectiveDense) {
     ASSERT_OK_AND_ASSIGN(auto test_nopre,
                          ExpressionFunctionCaller::Maker(name, {uint8()}));
     for (const auto& selection : selections) {
-      SelectionVectorSpan selection_span(selection->indices(), selection->length());
+      DiscreteSpan selection_span{selection->indices(), selection->length()};
       ResetContexts();
 
       DoTestBasic(test_nopre.get(), *arr, selection, [&](const Datum& result) {
@@ -2225,7 +2223,7 @@ TEST_F(TestCallScalarFunctionStatefulKernel, BasicSelectiveSparse) {
   ASSERT_OK_AND_ASSIGN(
       auto caller, ExpressionFunctionCaller::Maker("test_stateful_selective", {int32()}));
   for (const auto& selection : selections) {
-    SelectionVectorSpan selection_span(selection->indices(), selection->length());
+    DiscreteSpan selection_span{selection->indices(), selection->length()};
     ResetContexts();
 
     DoTestBasic(caller.get(), *input, multiplier, selection, [&](const Datum& result) {
@@ -2244,7 +2242,7 @@ TEST_F(TestCallScalarFunctionStatefulKernel, BasicSelectiveDense) {
   ASSERT_OK_AND_ASSIGN(auto caller,
                        ExpressionFunctionCaller::Maker("test_stateful", {int32()}));
   for (const auto& selection : selections) {
-    SelectionVectorSpan selection_span(selection->indices(), selection->length());
+    DiscreteSpan selection_span{selection->indices(), selection->length()};
     ResetContexts();
 
     DoTestBasic(caller.get(), *input, multiplier, selection, [&](const Datum& result) {

--- a/cpp/src/arrow/compute/exec_test.cc
+++ b/cpp/src/arrow/compute/exec_test.cc
@@ -169,10 +169,6 @@ TEST(SelectionVector, Validate) {
     ASSERT_RAISES(Invalid, sel_vector->Validate());
   }
   {
-    auto sel_vector = SelectionVectorFromJSON("[-42, 0]");
-    ASSERT_RAISES(Invalid, sel_vector->Validate());
-  }
-  {
     auto sel_vector = SelectionVectorFromJSON("[]");
     ASSERT_OK(sel_vector->Validate(/*values_length=*/0));
   }
@@ -191,8 +187,8 @@ TEST(SelectionVector, Validate) {
 }
 
 TEST(SelectionVectorSpan, Basics) {
-  auto indices = ArrayFromJSON(int32(), "[0, 3, 7]");
-  SelectionVectorSpan sel_span(indices->data()->GetValues<int32_t>(1),
+  auto indices = ArrayFromJSON(uint64(), "[0, 3, 7]");
+  SelectionVectorSpan sel_span(indices->data()->GetValues<uint64_t>(1),
                                indices->length() - 1,
                                /*offset=*/1, /*index_back_shift=*/1);
   ASSERT_EQ(sel_span[0], 2);
@@ -831,7 +827,9 @@ class TestExecSpanIterator : public TestComputeInternals {
       }
       if (iterator_.have_selection_vector()) {
         for (int64_t j = 0; j < selection.length(); ++j) {
-          ASSERT_EQ(input.selection_vector->indices()[selection_position + j] - position,
+          ASSERT_EQ(static_cast<int64_t>(
+                        input.selection_vector->indices()[selection_position + j]) -
+                        position,
                     selection[j]);
           ASSERT_GE(selection[j], 0);
           ASSERT_LT(selection[j], batch.length);

--- a/cpp/src/arrow/compute/exec_test.cc
+++ b/cpp/src/arrow/compute/exec_test.cc
@@ -17,6 +17,7 @@
 
 #include <cstring>
 #include <memory>
+#include <sstream>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -1216,6 +1217,22 @@ Status SelectiveExecCopyArraySpan(KernelContext* ctx, const ExecSpan& batch,
   return Status::OK();
 }
 
+Status SelectiveExecCopyOutputNotNullArraySpan(KernelContext* ctx, const ExecSpan& batch,
+                                               const SelectionSpan& selection,
+                                               ExecResult* out) {
+  DCHECK_EQ(1, batch.num_values());
+  int value_size = batch[0].type()->byte_width();
+  const ArraySpan& arg0 = batch[0].array;
+  ArraySpan* out_arr = out->array_span_mutable();
+  uint8_t* dst = out_arr->buffers[1].data + out_arr->offset * value_size;
+  const uint8_t* src = arg0.buffers[1].data + arg0.offset * value_size;
+  std::memset(dst, kNonSelectedByte, batch.length * value_size);
+  VisitSelectionSpanInline(selection, [&](int64_t i) {
+    std::memcpy(dst + i * value_size, src + i * value_size, value_size);
+  });
+  return Status::OK();
+}
+
 Status ExecComputedBitmap(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
   // Propagate nulls not used. Check that the out bitmap isn't the same already
   // as the input bitmap
@@ -1487,6 +1504,15 @@ class TestCallScalarFunction : public TestComputeInternals {
     kernel.null_handling = NullHandling::COMPUTED_PREALLOCATE;
     ASSERT_OK(func2->AddKernel(kernel));
     ASSERT_OK(registry->AddFunction(func2));
+
+    auto func3 =
+        std::make_shared<ScalarFunction>("test_copy_output_not_null_selective", Arity::Unary(),
+                                         /*doc=*/FunctionDoc::Empty());
+    ScalarKernel kernel3({uint8()}, uint8(), ExecCopyArraySpan,
+                         SelectiveExecCopyOutputNotNullArraySpan);
+    kernel3.null_handling = NullHandling::OUTPUT_NOT_NULL;
+    ASSERT_OK(func3->AddKernel(kernel3));
+    ASSERT_OK(registry->AddFunction(func3));
   }
 
   void AddNoPreallocateFunctions() {
@@ -1875,6 +1901,43 @@ TEST_F(TestCallScalarFunctionPreallocationCases, BasicSelectiveSparse) {
       });
     }
   }
+}
+
+TEST_F(TestCallScalarFunctionPreallocationCases, OutputNotNullSelectiveSparse) {
+  auto arr = GetUInt8Array(/*size=*/100, /*null_probability=*/0.2);
+  ASSERT_NE(arr->data()->buffers[0], nullptr);
+  const uint8_t* validity = arr->data()->buffers[0]->data();
+  const int64_t offset = arr->data()->offset;
+  std::vector<int64_t> valid_indices;
+  valid_indices.reserve(static_cast<size_t>(arr->length()));
+  for (int64_t i = 0; i < arr->length(); ++i) {
+    if (bit_util::GetBit(validity, offset + i)) {
+      valid_indices.push_back(i);
+    }
+  }
+  ASSERT_GE(valid_indices.size(), 3);
+  const int64_t idx0 = valid_indices.front();
+  const int64_t idx1 = valid_indices[valid_indices.size() / 2];
+  const int64_t idx2 = valid_indices.back();
+  ASSERT_LT(idx0, idx1);
+  ASSERT_LT(idx1, idx2);
+  std::stringstream selection_json;
+  selection_json << "[" << idx0 << ", " << idx1 << ", " << idx2 << "]";
+  auto selection = SelectionVectorFromJSON(selection_json.str());
+  SelectionSpan selection_span;
+  const int64_t consumed = selection->GetSpanForChunk(
+      /*chunk_start=*/0, static_cast<uint64_t>(arr->length()), /*selection_position=*/0,
+      &selection_span);
+  ASSERT_EQ(consumed, selection->length());
+
+  ASSERT_OK_AND_ASSIGN(auto test_copy,
+                       ExpressionFunctionCaller::Maker("test_copy_output_not_null_selective",
+                                                       {uint8()}));
+  ResetContexts();
+  DoTestBasic(test_copy.get(), *arr, selection, [&](const Datum& result) {
+    ASSERT_EQ(Datum::ARRAY, result.kind());
+    AssertArraysEqualSparseWithSelection(*arr, selection_span, *result.make_array());
+  });
 }
 
 TEST_F(TestCallScalarFunctionPreallocationCases, BasicSelectiveDense) {

--- a/cpp/src/arrow/compute/exec_test.cc
+++ b/cpp/src/arrow/compute/exec_test.cc
@@ -153,7 +153,7 @@ TEST(SelectionVector, Basics) {
 
   ASSERT_EQ(sel_vector->length(), 2);
   ASSERT_OK_AND_ASSIGN(auto indices_data, sel_vector->ToIndicesArrayData());
-  const uint64_t* indices = indices_data->GetValues<uint64_t>(1);
+  const int32_t* indices = indices_data->GetValues<int32_t>(1);
   ASSERT_NE(indices, nullptr);
   ASSERT_EQ(indices[0], 0);
   ASSERT_EQ(indices[1], 42);
@@ -170,6 +170,10 @@ TEST(SelectionVector, Validate) {
   }
   {
     auto sel_vector = SelectionVectorFromJSON("[42, 0]");
+    ASSERT_RAISES(Invalid, sel_vector->Validate());
+  }
+  {
+    auto sel_vector = SelectionVectorFromJSON("[-42, 0]");
     ASSERT_RAISES(Invalid, sel_vector->Validate());
   }
   {
@@ -191,8 +195,8 @@ TEST(SelectionVector, Validate) {
 }
 
 TEST(DiscreteSpan, Basics) {
-  auto indices = ArrayFromJSON(uint64(), "[0, 3, 7]");
-  const uint64_t* idx = indices->data()->GetValues<uint64_t>(1);
+  auto indices = ArrayFromJSON(int32(), "[0, 3, 7]");
+  const int32_t* idx = indices->data()->GetValues<int32_t>(1);
   DiscreteSpan sel_span{idx + 1, /*length=*/2, /*index_back_shift=*/1};
   ASSERT_EQ(sel_span[0], 2);
   ASSERT_EQ(sel_span[1], 6);
@@ -795,10 +799,10 @@ class TestExecSpanIterator : public TestComputeInternals {
                       const std::vector<int>& ex_selection_sizes) {
     SetupIterator(input, chunksize);
     std::shared_ptr<ArrayData> selection_indices;
-    const uint64_t* selection_indices_values = nullptr;
+    const int32_t* selection_indices_values = nullptr;
     if (input.selection_vector) {
       ASSERT_OK_AND_ASSIGN(selection_indices, input.selection_vector->ToIndicesArrayData());
-      selection_indices_values = selection_indices->GetValues<uint64_t>(1);
+      selection_indices_values = selection_indices->GetValues<int32_t>(1);
       ASSERT_NE(selection_indices_values, nullptr);
     }
     ExecSpan batch;

--- a/cpp/src/arrow/compute/exec_test.cc
+++ b/cpp/src/arrow/compute/exec_test.cc
@@ -189,6 +189,137 @@ TEST(SelectionVector, Validate) {
   }
 }
 
+TEST(SelectionVector, FromMask) {
+  {
+    auto mask = ArrayFromJSON(boolean(), "[true, null, false, true]");
+    ASSERT_OK_AND_ASSIGN(auto sel, SelectionVector::FromMask(*mask));
+    ASSERT_EQ(sel->length(), 2);
+    ASSERT_OK(sel->Validate(mask->length()));
+    ASSERT_OK_AND_ASSIGN(auto indices_data, sel->ToIndicesArrayData());
+    const uint64_t* indices = indices_data->GetValues<uint64_t>(1);
+    ASSERT_NE(indices, nullptr);
+    ASSERT_EQ(indices_data->length, 2);
+    ASSERT_EQ(indices[0], 0);
+    ASSERT_EQ(indices[1], 3);
+  }
+  {
+    // Ensure slice offsets are handled correctly.
+    auto base = ArrayFromJSON(boolean(), "[false, true, false, true]");
+    auto sliced = base->Slice(/*offset=*/1, /*length=*/2);  // [true, false]
+    ASSERT_OK_AND_ASSIGN(auto sel, SelectionVector::FromMask(*sliced));
+    ASSERT_EQ(sel->length(), 1);
+    ASSERT_OK(sel->Validate(sliced->length()));
+    ASSERT_OK_AND_ASSIGN(auto indices_data, sel->ToIndicesArrayData());
+    const uint64_t* indices = indices_data->GetValues<uint64_t>(1);
+    ASSERT_NE(indices, nullptr);
+    ASSERT_EQ(indices_data->length, 1);
+    ASSERT_EQ(indices[0], 0);
+  }
+}
+
+TEST(SelectionVector, FromRanges) {
+  const int64_t values_length = 10;
+  std::vector<SelectionRange> ranges = {SelectionRange{1, 2}, SelectionRange{5, 1}};
+  ASSERT_OK_AND_ASSIGN(auto sel, SelectionVector::FromRanges(ranges, values_length));
+  ASSERT_EQ(sel->length(), 3);
+  ASSERT_OK(sel->Validate(values_length));
+
+  ASSERT_OK_AND_ASSIGN(auto indices_data, sel->ToIndicesArrayData());
+  const uint64_t* indices = indices_data->GetValues<uint64_t>(1);
+  ASSERT_NE(indices, nullptr);
+  ASSERT_EQ(indices_data->length, 3);
+  ASSERT_EQ(indices[0], 1);
+  ASSERT_EQ(indices[1], 2);
+  ASSERT_EQ(indices[2], 5);
+
+  {
+    SelectionSpan span;
+    const int64_t consumed =
+        sel->GetSpanForChunk(/*chunk_start=*/0, /*chunk_end=*/4,
+                             /*selection_position=*/0, &span);
+    ASSERT_EQ(consumed, 2);
+    std::vector<int64_t> visited;
+    detail::VisitSelectionSpanInline(span, [&](int64_t i) { visited.push_back(i); });
+    ASSERT_EQ(visited, (std::vector<int64_t>{1, 2}));
+  }
+  {
+    SelectionSpan span;
+    const int64_t consumed =
+        sel->GetSpanForChunk(/*chunk_start=*/4, /*chunk_end=*/7,
+                             /*selection_position=*/2, &span);
+    ASSERT_EQ(consumed, 1);
+    std::vector<int64_t> visited;
+    detail::VisitSelectionSpanInline(span, [&](int64_t i) { visited.push_back(i); });
+    ASSERT_EQ(visited, (std::vector<int64_t>{1}));
+  }
+}
+
+Result<std::shared_ptr<SelectionVector>> SelectionVectorAsMask(
+    const SelectionVector& selection, int64_t values_length,
+    MemoryPool* pool = default_memory_pool()) {
+  if (pool == nullptr) {
+    pool = default_memory_pool();
+  }
+  if (values_length < 0) {
+    return Status::Invalid("values_length must be non-negative");
+  }
+  ARROW_ASSIGN_OR_RAISE(auto indices_data, selection.ToIndicesArrayData(pool));
+  ARROW_ASSIGN_OR_RAISE(auto bitmap, AllocateEmptyBitmap(values_length, pool));
+  uint8_t* bits = bitmap->mutable_data();
+  const uint64_t* indices = indices_data->GetValues<uint64_t>(1);
+  DCHECK(indices_data->length == 0 || indices != nullptr);
+  for (int64_t i = 0; i < indices_data->length; ++i) {
+    bit_util::SetBit(bits, static_cast<int64_t>(indices[i]));
+  }
+  auto mask_data =
+      ArrayData::Make(boolean(), values_length, {nullptr, std::move(bitmap)},
+                      /*null_count=*/0);
+  return SelectionVector::FromMask(*MakeArray(std::move(mask_data)), pool);
+}
+
+Result<std::shared_ptr<SelectionVector>> SelectionVectorAsRanges(
+    const SelectionVector& selection, int64_t values_length,
+    MemoryPool* pool = default_memory_pool()) {
+  if (pool == nullptr) {
+    pool = default_memory_pool();
+  }
+  if (values_length < 0) {
+    return Status::Invalid("values_length must be non-negative");
+  }
+  ARROW_ASSIGN_OR_RAISE(auto indices_data, selection.ToIndicesArrayData(pool));
+  const uint64_t* indices = indices_data->GetValues<uint64_t>(1);
+  DCHECK(indices_data->length == 0 || indices != nullptr);
+
+  std::vector<SelectionRange> ranges;
+  ranges.reserve(static_cast<size_t>(indices_data->length));
+  if (indices_data->length > 0) {
+    uint64_t start = indices[0];
+    uint64_t prev = indices[0];
+    for (int64_t i = 1; i < indices_data->length; ++i) {
+      const uint64_t cur = indices[i];
+      if (cur == prev + 1) {
+        prev = cur;
+        continue;
+      }
+      ranges.push_back(SelectionRange{start, prev - start + 1});
+      start = prev = cur;
+    }
+    ranges.push_back(SelectionRange{start, prev - start + 1});
+  }
+
+  return SelectionVector::FromRanges(std::move(ranges), values_length, pool);
+}
+
+template <typename Fn>
+void ForEachSelectionVectorBackend(const std::shared_ptr<SelectionVector>& base,
+                                   int64_t values_length, Fn&& fn) {
+  fn(base);
+  ASSERT_OK_AND_ASSIGN(auto mask, SelectionVectorAsMask(*base, values_length));
+  fn(mask);
+  ASSERT_OK_AND_ASSIGN(auto ranges, SelectionVectorAsRanges(*base, values_length));
+  fn(ranges);
+}
+
 TEST(DiscreteSpan, Basics) {
   auto indices = ArrayFromJSON(uint64(), "[0, 3, 7]");
   const uint64_t* idx = indices->data()->GetValues<uint64_t>(1);
@@ -985,11 +1116,69 @@ TEST_F(TestExecSpanIterator, SelectionSpanBasic) {
   CheckIteration(batch, /*chunksize=*/30, {30}, {4});
 }
 
+TEST_F(TestExecSpanIterator, SelectionSpanBasicMask) {
+  auto base_sel = SelectionVectorFromJSON("[1, 2, 7, 29]");
+  ASSERT_OK_AND_ASSIGN(auto sel, SelectionVectorAsMask(*base_sel, /*values_length=*/30));
+  ExecBatch batch(
+      {Datum(GetInt32Array(30)), Datum(GetInt32Array(30)),
+       Datum(std::make_shared<Int32Scalar>(5)), Datum(MakeNullScalar(boolean()))},
+      30, std::move(sel));
+
+  CheckIteration(batch, /*chunksize=*/7, {7, 7, 7, 7, 2}, {2, 1, 0, 0, 1});
+  CheckIteration(batch, /*chunksize=*/10, {10, 10, 10}, {3, 0, 1});
+  CheckIteration(batch, /*chunksize=*/20, {20, 10}, {3, 1});
+  CheckIteration(batch, /*chunksize=*/30, {30}, {4});
+}
+
+TEST_F(TestExecSpanIterator, SelectionSpanBasicRanges) {
+  auto base_sel = SelectionVectorFromJSON("[1, 2, 7, 29]");
+  ASSERT_OK_AND_ASSIGN(auto sel,
+                       SelectionVectorAsRanges(*base_sel, /*values_length=*/30));
+  ExecBatch batch(
+      {Datum(GetInt32Array(30)), Datum(GetInt32Array(30)),
+       Datum(std::make_shared<Int32Scalar>(5)), Datum(MakeNullScalar(boolean()))},
+      30, std::move(sel));
+
+  CheckIteration(batch, /*chunksize=*/7, {7, 7, 7, 7, 2}, {2, 1, 0, 0, 1});
+  CheckIteration(batch, /*chunksize=*/10, {10, 10, 10}, {3, 0, 1});
+  CheckIteration(batch, /*chunksize=*/20, {20, 10}, {3, 1});
+  CheckIteration(batch, /*chunksize=*/30, {30}, {4});
+}
+
 TEST_F(TestExecSpanIterator, SelectionSpanChunked) {
   ExecBatch batch({Datum(GetInt32Chunked({0, 20, 10})), Datum(GetInt32Chunked({15, 15})),
                    Datum(GetInt32Array(30)), Datum(std::make_shared<Int32Scalar>(5)),
                    Datum(MakeNullScalar(boolean()))},
                   30, SelectionVectorFromJSON("[1, 2, 7, 29]"));
+
+  CheckIteration(batch, /*chunksize=*/7, {7, 7, 1, 5, 7, 3}, {2, 1, 0, 0, 0, 1});
+  CheckIteration(batch, /*chunksize=*/10, {10, 5, 5, 10}, {3, 0, 0, 1});
+  CheckIteration(batch, /*chunksize=*/20, {15, 5, 10}, {3, 0, 1});
+  CheckIteration(batch, /*chunksize=*/30, {15, 5, 10}, {3, 0, 1});
+}
+
+TEST_F(TestExecSpanIterator, SelectionSpanChunkedMask) {
+  auto base_sel = SelectionVectorFromJSON("[1, 2, 7, 29]");
+  ASSERT_OK_AND_ASSIGN(auto sel, SelectionVectorAsMask(*base_sel, /*values_length=*/30));
+  ExecBatch batch({Datum(GetInt32Chunked({0, 20, 10})), Datum(GetInt32Chunked({15, 15})),
+                   Datum(GetInt32Array(30)), Datum(std::make_shared<Int32Scalar>(5)),
+                   Datum(MakeNullScalar(boolean()))},
+                  30, std::move(sel));
+
+  CheckIteration(batch, /*chunksize=*/7, {7, 7, 1, 5, 7, 3}, {2, 1, 0, 0, 0, 1});
+  CheckIteration(batch, /*chunksize=*/10, {10, 5, 5, 10}, {3, 0, 0, 1});
+  CheckIteration(batch, /*chunksize=*/20, {15, 5, 10}, {3, 0, 1});
+  CheckIteration(batch, /*chunksize=*/30, {15, 5, 10}, {3, 0, 1});
+}
+
+TEST_F(TestExecSpanIterator, SelectionSpanChunkedRanges) {
+  auto base_sel = SelectionVectorFromJSON("[1, 2, 7, 29]");
+  ASSERT_OK_AND_ASSIGN(auto sel,
+                       SelectionVectorAsRanges(*base_sel, /*values_length=*/30));
+  ExecBatch batch({Datum(GetInt32Chunked({0, 20, 10})), Datum(GetInt32Chunked({15, 15})),
+                   Datum(GetInt32Array(30)), Datum(std::make_shared<Int32Scalar>(5)),
+                   Datum(MakeNullScalar(boolean()))},
+                  30, std::move(sel));
 
   CheckIteration(batch, /*chunksize=*/7, {7, 7, 1, 5, 7, 3}, {2, 1, 0, 0, 0, 1});
   CheckIteration(batch, /*chunksize=*/10, {10, 5, 5, 10}, {3, 0, 0, 1});
@@ -1210,13 +1399,20 @@ Status ExecComputedBitmap(KernelContext* ctx, const ExecSpan& batch, ExecResult*
   // as the input bitmap
   const ArraySpan& arg0 = batch[0].array;
   ArraySpan* out_arr = out->array_span_mutable();
-  if (CountSetBits(arg0.buffers[0].data, arg0.offset, batch.length) > 0) {
+  const uint8_t* src_validity = arg0.buffers[0].data;
+  if (src_validity == nullptr) {
+    // A null validity bitmap means "all valid".
+    bit_util::SetBitsTo(out_arr->buffers[0].data, out_arr->offset, batch.length, true);
+    return ExecCopyArraySpan(ctx, batch, out);
+  }
+
+  if (CountSetBits(src_validity, arg0.offset, batch.length) > 0) {
     // Check that the bitmap has not been already copied over
-    DCHECK(!BitmapEquals(arg0.buffers[0].data, arg0.offset, out_arr->buffers[0].data,
+    DCHECK(!BitmapEquals(src_validity, arg0.offset, out_arr->buffers[0].data,
                          out_arr->offset, batch.length));
   }
 
-  CopyBitmap(arg0.buffers[0].data, arg0.offset, batch.length, out_arr->buffers[0].data,
+  CopyBitmap(src_validity, arg0.offset, batch.length, out_arr->buffers[0].data,
              out_arr->offset);
   return ExecCopyArraySpan(ctx, batch, out);
 }
@@ -1228,13 +1424,20 @@ Status SelectiveExecComputedBitmap(KernelContext* ctx, const ExecSpan& batch,
   // as the input bitmap
   const ArraySpan& arg0 = batch[0].array;
   ArraySpan* out_arr = out->array_span_mutable();
-  if (CountSetBits(arg0.buffers[0].data, arg0.offset, batch.length) > 0) {
+  const uint8_t* src_validity = arg0.buffers[0].data;
+  if (src_validity == nullptr) {
+    // A null validity bitmap means "all valid".
+    bit_util::SetBitsTo(out_arr->buffers[0].data, out_arr->offset, batch.length, true);
+    return SelectiveExecCopyArraySpan(ctx, batch, selection, out);
+  }
+
+  if (CountSetBits(src_validity, arg0.offset, batch.length) > 0) {
     // Check that the bitmap has not been already copied over
-    DCHECK(!BitmapEquals(arg0.buffers[0].data, arg0.offset, out_arr->buffers[0].data,
+    DCHECK(!BitmapEquals(src_validity, arg0.offset, out_arr->buffers[0].data,
                          out_arr->offset, batch.length));
   }
 
-  CopyBitmap(arg0.buffers[0].data, arg0.offset, batch.length, out_arr->buffers[0].data,
+  CopyBitmap(src_validity, arg0.offset, batch.length, out_arr->buffers[0].data,
              out_arr->offset);
   return SelectiveExecCopyArraySpan(ctx, batch, selection, out);
 }
@@ -1850,18 +2053,22 @@ TEST_F(TestCallScalarFunctionPreallocationCases, BasicSelectiveSparse) {
     ARROW_SCOPED_TRACE(name);
     ASSERT_OK_AND_ASSIGN(auto test_copy,
                          ExpressionFunctionCaller::Maker(name, {uint8()}));
-    for (const auto& selection : selections) {
-      SelectionSpan selection_span;
-      const int64_t consumed = selection->GetSpanForChunk(
-          /*chunk_start=*/0, static_cast<uint64_t>(arr->length()),
-          /*selection_position=*/0, &selection_span);
-      ASSERT_EQ(consumed, selection->length());
-      ResetContexts();
+    for (const auto& base : selections) {
+      ForEachSelectionVectorBackend(
+          base, arr->length(), [&](const std::shared_ptr<SelectionVector>& selection) {
+            SelectionSpan selection_span;
+            const int64_t consumed = selection->GetSpanForChunk(
+                /*chunk_start=*/0, static_cast<uint64_t>(arr->length()),
+                /*selection_position=*/0, &selection_span);
+            ASSERT_EQ(consumed, selection->length());
+            ResetContexts();
 
-      DoTestBasic(test_copy.get(), *arr, selection, [&](const Datum& result) {
-        ASSERT_EQ(Datum::ARRAY, result.kind());
-        AssertArraysEqualSparseWithSelection(*arr, selection_span, *result.make_array());
-      });
+            DoTestBasic(test_copy.get(), *arr, selection, [&](const Datum& result) {
+              ASSERT_EQ(Datum::ARRAY, result.kind());
+              AssertArraysEqualSparseWithSelection(*arr, selection_span,
+                                                   *result.make_array());
+            });
+          });
     }
   }
 }
@@ -1873,18 +2080,22 @@ TEST_F(TestCallScalarFunctionPreallocationCases, BasicSelectiveDense) {
     ARROW_SCOPED_TRACE(name);
     ASSERT_OK_AND_ASSIGN(auto test_copy,
                          ExpressionFunctionCaller::Maker(name, {uint8()}));
-    for (const auto& selection : selections) {
-      SelectionSpan selection_span;
-      const int64_t consumed = selection->GetSpanForChunk(
-          /*chunk_start=*/0, static_cast<uint64_t>(arr->length()),
-          /*selection_position=*/0, &selection_span);
-      ASSERT_EQ(consumed, selection->length());
-      ResetContexts();
+    for (const auto& base : selections) {
+      ForEachSelectionVectorBackend(
+          base, arr->length(), [&](const std::shared_ptr<SelectionVector>& selection) {
+            SelectionSpan selection_span;
+            const int64_t consumed = selection->GetSpanForChunk(
+                /*chunk_start=*/0, static_cast<uint64_t>(arr->length()),
+                /*selection_position=*/0, &selection_span);
+            ASSERT_EQ(consumed, selection->length());
+            ResetContexts();
 
-      DoTestBasic(test_copy.get(), *arr, selection, [&](const Datum& result) {
-        ASSERT_EQ(Datum::ARRAY, result.kind());
-        AssertArraysEqualDenseWithSelection(*arr, selection_span, *result.make_array());
-      });
+            DoTestBasic(test_copy.get(), *arr, selection, [&](const Datum& result) {
+              ASSERT_EQ(Datum::ARRAY, result.kind());
+              AssertArraysEqualDenseWithSelection(*arr, selection_span,
+                                                  *result.make_array());
+            });
+          });
     }
   }
 }
@@ -1923,20 +2134,24 @@ TEST_F(TestCallScalarFunctionPreallocationCases, ChunkedSelectiveSparse) {
     ARROW_SCOPED_TRACE(name);
     ASSERT_OK_AND_ASSIGN(auto test_copy,
                          ExpressionFunctionCaller::Maker(name, {uint8()}));
-    for (const auto& selection : selections) {
-      SelectionSpan selection_span;
-      const int64_t consumed = selection->GetSpanForChunk(
-          /*chunk_start=*/0, static_cast<uint64_t>(arr->length()),
-          /*selection_position=*/0, &selection_span);
-      ASSERT_EQ(consumed, selection->length());
-      ResetContexts();
+    for (const auto& base : selections) {
+      ForEachSelectionVectorBackend(
+          base, arr->length(), [&](const std::shared_ptr<SelectionVector>& selection) {
+            SelectionSpan selection_span;
+            const int64_t consumed = selection->GetSpanForChunk(
+                /*chunk_start=*/0, static_cast<uint64_t>(arr->length()),
+                /*selection_position=*/0, &selection_span);
+            ASSERT_EQ(consumed, selection->length());
+            ResetContexts();
 
-      DoTestChunked(test_copy.get(), *carr, selection, [&](const Datum& result) {
-        ASSERT_EQ(Datum::CHUNKED_ARRAY, result.kind());
-        std::shared_ptr<ChunkedArray> actual = result.chunked_array();
-        ASSERT_EQ(1, actual->num_chunks());
-        AssertArraysEqualSparseWithSelection(*arr, selection_span, *actual->chunk(0));
-      });
+            DoTestChunked(test_copy.get(), *carr, selection, [&](const Datum& result) {
+              ASSERT_EQ(Datum::CHUNKED_ARRAY, result.kind());
+              std::shared_ptr<ChunkedArray> actual = result.chunked_array();
+              ASSERT_EQ(1, actual->num_chunks());
+              AssertArraysEqualSparseWithSelection(*arr, selection_span,
+                                                   *actual->chunk(0));
+            });
+          });
     }
   }
 }
@@ -1950,20 +2165,24 @@ TEST_F(TestCallScalarFunctionPreallocationCases, ChunkedSelectiveDense) {
     ARROW_SCOPED_TRACE(name);
     ASSERT_OK_AND_ASSIGN(auto test_copy,
                          ExpressionFunctionCaller::Maker(name, {uint8()}));
-    for (const auto& selection : selections) {
-      SelectionSpan selection_span;
-      const int64_t consumed = selection->GetSpanForChunk(
-          /*chunk_start=*/0, static_cast<uint64_t>(arr->length()),
-          /*selection_position=*/0, &selection_span);
-      ASSERT_EQ(consumed, selection->length());
-      ResetContexts();
+    for (const auto& base : selections) {
+      ForEachSelectionVectorBackend(
+          base, arr->length(), [&](const std::shared_ptr<SelectionVector>& selection) {
+            SelectionSpan selection_span;
+            const int64_t consumed = selection->GetSpanForChunk(
+                /*chunk_start=*/0, static_cast<uint64_t>(arr->length()),
+                /*selection_position=*/0, &selection_span);
+            ASSERT_EQ(consumed, selection->length());
+            ResetContexts();
 
-      DoTestChunked(test_copy.get(), *carr, selection, [&](const Datum& result) {
-        ASSERT_EQ(Datum::CHUNKED_ARRAY, result.kind());
-        std::shared_ptr<ChunkedArray> actual = result.chunked_array();
-        ASSERT_EQ(1, actual->num_chunks());
-        AssertArraysEqualDenseWithSelection(*arr, selection_span, *actual->chunk(0));
-      });
+            DoTestChunked(test_copy.get(), *carr, selection, [&](const Datum& result) {
+              ASSERT_EQ(Datum::CHUNKED_ARRAY, result.kind());
+              std::shared_ptr<ChunkedArray> actual = result.chunked_array();
+              ASSERT_EQ(1, actual->num_chunks());
+              AssertArraysEqualDenseWithSelection(*arr, selection_span,
+                                                  *actual->chunk(0));
+            });
+          });
     }
   }
 }
@@ -2001,15 +2220,18 @@ TEST_F(TestCallScalarFunctionPreallocationCases, IndependentPreallocateSelective
     ARROW_SCOPED_TRACE(name);
     ASSERT_OK_AND_ASSIGN(auto test_copy,
                          ExpressionFunctionCaller::Maker(name, {uint8()}));
-    for (const auto& selection : selections) {
-      const int64_t exec_chunksize = 40;
-      ResetContexts();
+    for (const auto& base : selections) {
+      ForEachSelectionVectorBackend(
+          base, arr->length(), [&](const std::shared_ptr<SelectionVector>& selection) {
+            const int64_t exec_chunksize = 40;
+            ResetContexts();
 
-      DoTestIndependentPreallocate(test_copy.get(), exec_chunksize, *arr, selection,
-                                   [&](const Datum& result) {
-                                     AssertChunkedExecResultsEqualSparseWithSelection(
-                                         exec_chunksize, *arr, selection.get(), result);
-                                   });
+            DoTestIndependentPreallocate(
+                test_copy.get(), exec_chunksize, *arr, selection, [&](const Datum& result) {
+                  AssertChunkedExecResultsEqualSparseWithSelection(
+                      exec_chunksize, *arr, selection.get(), result);
+                });
+          });
     }
   }
 }
@@ -2021,15 +2243,18 @@ TEST_F(TestCallScalarFunctionPreallocationCases, IndependentPreallocateSelective
     ARROW_SCOPED_TRACE(name);
     ASSERT_OK_AND_ASSIGN(auto test_copy,
                          ExpressionFunctionCaller::Maker(name, {uint8()}));
-    for (const auto& selection : selections) {
-      const int64_t exec_chunksize = 40;
-      ResetContexts();
+    for (const auto& base : selections) {
+      ForEachSelectionVectorBackend(
+          base, arr->length(), [&](const std::shared_ptr<SelectionVector>& selection) {
+            const int64_t exec_chunksize = 40;
+            ResetContexts();
 
-      DoTestIndependentPreallocate(test_copy.get(), exec_chunksize, *arr, selection,
-                                   [&](const Datum& result) {
-                                     AssertChunkedExecResultsEqualDenseWithSelection(
-                                         exec_chunksize, *arr, selection.get(), result);
-                                   });
+            DoTestIndependentPreallocate(
+                test_copy.get(), exec_chunksize, *arr, selection, [&](const Datum& result) {
+                  AssertChunkedExecResultsEqualDenseWithSelection(
+                      exec_chunksize, *arr, selection.get(), result);
+                });
+          });
     }
   }
 }
@@ -2100,18 +2325,22 @@ TEST_F(TestCallScalarFunctionBasicNonStandardCases, BasicSelectiveSparse) {
     ARROW_SCOPED_TRACE(name);
     ASSERT_OK_AND_ASSIGN(auto test_nopre,
                          ExpressionFunctionCaller::Maker(name, {uint8()}));
-    for (const auto& selection : selections) {
-      SelectionSpan selection_span;
-      const int64_t consumed = selection->GetSpanForChunk(
-          /*chunk_start=*/0, static_cast<uint64_t>(arr->length()),
-          /*selection_position=*/0, &selection_span);
-      ASSERT_EQ(consumed, selection->length());
-      ResetContexts();
+    for (const auto& base : selections) {
+      ForEachSelectionVectorBackend(
+          base, arr->length(), [&](const std::shared_ptr<SelectionVector>& selection) {
+            SelectionSpan selection_span;
+            const int64_t consumed = selection->GetSpanForChunk(
+                /*chunk_start=*/0, static_cast<uint64_t>(arr->length()),
+                /*selection_position=*/0, &selection_span);
+            ASSERT_EQ(consumed, selection->length());
+            ResetContexts();
 
-      DoTestBasic(test_nopre.get(), *arr, selection, [&](const Datum& result) {
-        ASSERT_EQ(Datum::ARRAY, result.kind());
-        AssertArraysEqualSparseWithSelection(*arr, selection_span, *result.make_array());
-      });
+            DoTestBasic(test_nopre.get(), *arr, selection, [&](const Datum& result) {
+              ASSERT_EQ(Datum::ARRAY, result.kind());
+              AssertArraysEqualSparseWithSelection(*arr, selection_span,
+                                                   *result.make_array());
+            });
+          });
     }
   }
 }
@@ -2123,18 +2352,22 @@ TEST_F(TestCallScalarFunctionBasicNonStandardCases, BasicSelectiveDense) {
     ARROW_SCOPED_TRACE(name);
     ASSERT_OK_AND_ASSIGN(auto test_nopre,
                          ExpressionFunctionCaller::Maker(name, {uint8()}));
-    for (const auto& selection : selections) {
-      SelectionSpan selection_span;
-      const int64_t consumed = selection->GetSpanForChunk(
-          /*chunk_start=*/0, static_cast<uint64_t>(arr->length()),
-          /*selection_position=*/0, &selection_span);
-      ASSERT_EQ(consumed, selection->length());
-      ResetContexts();
+    for (const auto& base : selections) {
+      ForEachSelectionVectorBackend(
+          base, arr->length(), [&](const std::shared_ptr<SelectionVector>& selection) {
+            SelectionSpan selection_span;
+            const int64_t consumed = selection->GetSpanForChunk(
+                /*chunk_start=*/0, static_cast<uint64_t>(arr->length()),
+                /*selection_position=*/0, &selection_span);
+            ASSERT_EQ(consumed, selection->length());
+            ResetContexts();
 
-      DoTestBasic(test_nopre.get(), *arr, selection, [&](const Datum& result) {
-        ASSERT_EQ(Datum::ARRAY, result.kind());
-        AssertArraysEqualDenseWithSelection(*arr, selection_span, *result.make_array());
-      });
+            DoTestBasic(test_nopre.get(), *arr, selection, [&](const Datum& result) {
+              ASSERT_EQ(Datum::ARRAY, result.kind());
+              AssertArraysEqualDenseWithSelection(*arr, selection_span,
+                                                  *result.make_array());
+            });
+          });
     }
   }
 }
@@ -2171,15 +2404,18 @@ TEST_F(TestCallScalarFunctionBasicNonStandardCases, SplitExecutionSelectiveSpars
     ARROW_SCOPED_TRACE(name);
     ASSERT_OK_AND_ASSIGN(auto test_nopre,
                          ExpressionFunctionCaller::Maker(name, {uint8()}));
-    for (const auto& selection : selections) {
-      const int64_t exec_chunksize = 400;
-      ResetContexts();
+    for (const auto& base : selections) {
+      ForEachSelectionVectorBackend(
+          base, arr->length(), [&](const std::shared_ptr<SelectionVector>& selection) {
+            const int64_t exec_chunksize = 400;
+            ResetContexts();
 
-      DoTestSplitExecution(test_nopre.get(), exec_chunksize, *arr, selection,
-                           [&](const Datum& result) {
-                             AssertChunkedExecResultsEqualSparseWithSelection(
-                                 exec_chunksize, *arr, selection.get(), result);
-                           });
+            DoTestSplitExecution(test_nopre.get(), exec_chunksize, *arr, selection,
+                                 [&](const Datum& result) {
+                                   AssertChunkedExecResultsEqualSparseWithSelection(
+                                       exec_chunksize, *arr, selection.get(), result);
+                                 });
+          });
     }
   }
 }
@@ -2191,15 +2427,18 @@ TEST_F(TestCallScalarFunctionBasicNonStandardCases, SplitExecutionSelectiveDense
     ARROW_SCOPED_TRACE(name);
     ASSERT_OK_AND_ASSIGN(auto test_nopre,
                          ExpressionFunctionCaller::Maker(name, {uint8()}));
-    for (const auto& selection : selections) {
-      const int64_t exec_chunksize = 400;
-      ResetContexts();
+    for (const auto& base : selections) {
+      ForEachSelectionVectorBackend(
+          base, arr->length(), [&](const std::shared_ptr<SelectionVector>& selection) {
+            const int64_t exec_chunksize = 400;
+            ResetContexts();
 
-      DoTestSplitExecution(test_nopre.get(), exec_chunksize, *arr, selection,
-                           [&](const Datum& result) {
-                             AssertChunkedExecResultsEqualDenseWithSelection(
-                                 exec_chunksize, *arr, selection.get(), result);
-                           });
+            DoTestSplitExecution(test_nopre.get(), exec_chunksize, *arr, selection,
+                                 [&](const Datum& result) {
+                                   AssertChunkedExecResultsEqualDenseWithSelection(
+                                       exec_chunksize, *arr, selection.get(), result);
+                                 });
+          });
     }
   }
 }
@@ -2256,19 +2495,22 @@ TEST_F(TestCallScalarFunctionStatefulKernel, BasicSelectiveSparse) {
   auto expected = GetExpected();
   ASSERT_OK_AND_ASSIGN(
       auto caller, ExpressionFunctionCaller::Maker("test_stateful_selective", {int32()}));
-  for (const auto& selection : selections) {
-    SelectionSpan selection_span;
-    const int64_t consumed = selection->GetSpanForChunk(
-        /*chunk_start=*/0, static_cast<uint64_t>(input->length()),
-        /*selection_position=*/0, &selection_span);
-    ASSERT_EQ(consumed, selection->length());
-    ResetContexts();
+  for (const auto& base : selections) {
+    ForEachSelectionVectorBackend(
+        base, input->length(), [&](const std::shared_ptr<SelectionVector>& selection) {
+          SelectionSpan selection_span;
+          const int64_t consumed = selection->GetSpanForChunk(
+              /*chunk_start=*/0, static_cast<uint64_t>(input->length()),
+              /*selection_position=*/0, &selection_span);
+          ASSERT_EQ(consumed, selection->length());
+          ResetContexts();
 
-    DoTestBasic(caller.get(), *input, multiplier, selection, [&](const Datum& result) {
-      ASSERT_EQ(Datum::ARRAY, result.kind());
-      AssertArraysEqualSparseWithSelection(*expected, selection_span,
-                                           *result.make_array());
-    });
+          DoTestBasic(caller.get(), *input, multiplier, selection, [&](const Datum& result) {
+            ASSERT_EQ(Datum::ARRAY, result.kind());
+            AssertArraysEqualSparseWithSelection(*expected, selection_span,
+                                                 *result.make_array());
+          });
+        });
   }
 }
 
@@ -2279,19 +2521,22 @@ TEST_F(TestCallScalarFunctionStatefulKernel, BasicSelectiveDense) {
   auto expected = GetExpected();
   ASSERT_OK_AND_ASSIGN(auto caller,
                        ExpressionFunctionCaller::Maker("test_stateful", {int32()}));
-  for (const auto& selection : selections) {
-    SelectionSpan selection_span;
-    const int64_t consumed = selection->GetSpanForChunk(
-        /*chunk_start=*/0, static_cast<uint64_t>(input->length()),
-        /*selection_position=*/0, &selection_span);
-    ASSERT_EQ(consumed, selection->length());
-    ResetContexts();
+  for (const auto& base : selections) {
+    ForEachSelectionVectorBackend(
+        base, input->length(), [&](const std::shared_ptr<SelectionVector>& selection) {
+          SelectionSpan selection_span;
+          const int64_t consumed = selection->GetSpanForChunk(
+              /*chunk_start=*/0, static_cast<uint64_t>(input->length()),
+              /*selection_position=*/0, &selection_span);
+          ASSERT_EQ(consumed, selection->length());
+          ResetContexts();
 
-    DoTestBasic(caller.get(), *input, multiplier, selection, [&](const Datum& result) {
-      ASSERT_EQ(Datum::ARRAY, result.kind());
-      AssertArraysEqualDenseWithSelection(*expected, selection_span,
-                                          *result.make_array());
-    });
+          DoTestBasic(caller.get(), *input, multiplier, selection, [&](const Datum& result) {
+            ASSERT_EQ(Datum::ARRAY, result.kind());
+            AssertArraysEqualDenseWithSelection(*expected, selection_span,
+                                                *result.make_array());
+          });
+        });
   }
 }
 

--- a/cpp/src/arrow/compute/kernel.h
+++ b/cpp/src/arrow/compute/kernel.h
@@ -556,11 +556,11 @@ struct ARROW_EXPORT Kernel {
 using ArrayKernelExec = Status (*)(KernelContext*, const ExecSpan&, ExecResult*);
 
 /// \brief The optional scalar kernel selective execution API for SCALAR kernel types.
-/// It's like ArrayKernelExec but with an additional SelectionVectorSpan argument. When a
+/// It's like ArrayKernelExec but with an additional SelectionSpan argument. When a
 /// selection vector is specified in the batch, this API will be preferred, if provided,
 /// over ArrayKernelExec.
 using ArrayKernelSelectiveExec = Status (*)(KernelContext*, const ExecSpan&,
-                                            const SelectionVectorSpan&, ExecResult*);
+                                            const SelectionSpan&, ExecResult*);
 
 /// \brief Kernel data structure for implementations of ScalarFunction. In
 /// addition to the members found in Kernel, contains the null handling

--- a/cpp/src/arrow/compute/test_util_internal.cc
+++ b/cpp/src/arrow/compute/test_util_internal.cc
@@ -122,14 +122,14 @@ void ValidateOutput(const Datum& output) {
 }
 
 std::shared_ptr<SelectionVector> SelectionVectorFromJSON(const std::string& json) {
-  return std::make_shared<SelectionVector>(*ArrayFromJSON(uint64(), json));
+  return SelectionVector::MakeIndices(*ArrayFromJSON(uint64(), json));
 }
 
 std::shared_ptr<SelectionVector> MakeSelectionVectorTo(int64_t length) {
   auto res = gen::Step<uint64_t>()->Generate(length);
   DCHECK_OK(res.status());
   auto arr = res.ValueUnsafe();
-  return std::make_shared<SelectionVector>(*arr);
+  return SelectionVector::MakeIndices(*arr);
 }
 
 }  // namespace arrow::compute

--- a/cpp/src/arrow/compute/test_util_internal.cc
+++ b/cpp/src/arrow/compute/test_util_internal.cc
@@ -122,11 +122,11 @@ void ValidateOutput(const Datum& output) {
 }
 
 std::shared_ptr<SelectionVector> SelectionVectorFromJSON(const std::string& json) {
-  return std::make_shared<SelectionVector>(*ArrayFromJSON(int32(), json));
+  return std::make_shared<SelectionVector>(*ArrayFromJSON(uint64(), json));
 }
 
 std::shared_ptr<SelectionVector> MakeSelectionVectorTo(int64_t length) {
-  auto res = gen::Step<int32_t>()->Generate(length);
+  auto res = gen::Step<uint64_t>()->Generate(length);
   DCHECK_OK(res.status());
   auto arr = res.ValueUnsafe();
   return std::make_shared<SelectionVector>(*arr);

--- a/cpp/src/arrow/compute/test_util_internal.cc
+++ b/cpp/src/arrow/compute/test_util_internal.cc
@@ -122,11 +122,11 @@ void ValidateOutput(const Datum& output) {
 }
 
 std::shared_ptr<SelectionVector> SelectionVectorFromJSON(const std::string& json) {
-  return SelectionVector::MakeIndices(*ArrayFromJSON(uint64(), json));
+  return SelectionVector::MakeIndices(*ArrayFromJSON(int32(), json));
 }
 
 std::shared_ptr<SelectionVector> MakeSelectionVectorTo(int64_t length) {
-  auto res = gen::Step<uint64_t>()->Generate(length);
+  auto res = gen::Step<int32_t>()->Generate(length);
   DCHECK_OK(res.status());
   auto arr = res.ValueUnsafe();
   return SelectionVector::MakeIndices(*arr);


### PR DESCRIPTION
Addresses pitrou review feedback on apache/arrow#47377:

- Use 64-bit indices for SelectionVector (UInt64).
- Introduce SelectionSpan (ContiguousSpan / FilteredSpan / DiscreteSpan) and update selective_exec to take SelectionSpan.
- Provide VisitSelectionSpanInline helper; ExecSpanIterator currently emits DiscreteSpan only.
- Cast SelectionVector indices to int64 in dense gather/execute/scatter fallback since Scatter only accepts signed indices.

Local verification (macOS arm64, Debug):
- Configured and built with CMake + Ninja
- Ran unit tests with:
  - `PYTHON=python3`
  - `ARROW_TEST_DATA=$PWD/testing/data` (requires `git submodule update --init testing`)
  - `ctest --test-dir cpp/build/selspan-debug -j 8 --output-on-failure` (50/50 passed)
