### PR TITLE
[codex] Refactor if_else decimal dispatch with match constraint

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_if_else.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else.cc
@@ -1242,13 +1242,11 @@ struct ResolveIfElseExec<NullType, AllocateMem> {
 struct IfElseFunction : ScalarFunction {
   using ScalarFunction::ScalarFunction;
 
-  static std::shared_ptr<MatchConstraint> DecimalMatchConstraint() {
+  static std::shared_ptr<MatchConstraint> ValueTypesMatchConstraint() {
     static auto constraint =
         MatchConstraint::Make([](const std::vector<TypeHolder>& types) -> bool {
           DCHECK_EQ(types.size(), 3);
           DCHECK_EQ(types[0].id(), Type::BOOL);
-          DCHECK(is_decimal(types[1].id()));
-          DCHECK(is_decimal(types[2].id()));
           return types[1] == types[2];
         });
     return constraint;
@@ -1258,8 +1256,6 @@ struct IfElseFunction : ScalarFunction {
     RETURN_NOT_OK(CheckArity(types->size()));
 
     using arrow::compute::detail::DispatchExactImpl;
-    // Do not DispatchExact here because it'll let through something like (bool,
-    // timestamp[s], timestamp[s, "UTC"])
 
     // if 0th type is null, replace with bool
     if (types->at(0).id() == Type::NA) {
@@ -1271,15 +1267,7 @@ struct IfElseFunction : ScalarFunction {
     constexpr size_t num_args = 2;
 
     internal::ReplaceNullWithOtherType(left_arg, num_args);
-
-    // If both are identical dictionary types, dispatch to the dictionary kernel
-    // TODO(ARROW-14105): apply implicit casts to dictionary types too
-    TypeHolder* right_arg = &(*types)[2];
-    if (is_dictionary(left_arg->id()) && left_arg->type->Equals(*right_arg->type)) {
-      auto kernel = DispatchExactImpl(this, *types);
-      DCHECK(kernel);
-      return kernel;
-    }
+    if (auto kernel = DispatchExactImpl(this, *types)) return kernel;
 
     internal::EnsureDictionaryDecoded(left_arg, num_args);
 
@@ -1322,7 +1310,7 @@ void AddPrimitiveIfElseKernels(const std::shared_ptr<ScalarFunction>& scalar_fun
       auto unit = checked_cast<const TimestampType&>(*type).unit();
       sig = KernelSignature::Make(
           {boolean(), match::TimestampTypeUnit(unit), match::TimestampTypeUnit(unit)},
-          LastType);
+          LastType, /*is_varargs=*/false, IfElseFunction::ValueTypesMatchConstraint());
     } else {
       sig = KernelSignature::Make({boolean(), type, type}, type);
     }
@@ -1356,8 +1344,8 @@ template <typename T>
 void AddFixedWidthIfElseKernel(const std::shared_ptr<IfElseFunction>& scalar_function) {
   auto type_id = T::type_id;
   std::shared_ptr<MatchConstraint> constraint = nullptr;
-  if (is_decimal(type_id)) {
-    constraint = IfElseFunction::DecimalMatchConstraint();
+  if (!TypeTraits<T>::is_parameter_free) {
+    constraint = IfElseFunction::ValueTypesMatchConstraint();
   }
   ScalarKernel kernel(
       KernelSignature::Make({boolean(), InputType(type_id), InputType(type_id)}, LastType,
@@ -1375,8 +1363,11 @@ void AddNestedIfElseKernels(const std::shared_ptr<IfElseFunction>& scalar_functi
        {Type::LIST, Type::LARGE_LIST, Type::LIST_VIEW, Type::LARGE_LIST_VIEW,
         Type::FIXED_SIZE_LIST, Type::MAP, Type::STRUCT, Type::DENSE_UNION,
         Type::SPARSE_UNION, Type::DICTIONARY}) {
-    ScalarKernel kernel({boolean(), InputType(type_id), InputType(type_id)}, LastType,
-                        NestedIfElseExec::Exec);
+    ScalarKernel kernel(
+        KernelSignature::Make({boolean(), InputType(type_id), InputType(type_id)}, LastType,
+                              /*is_varargs=*/false,
+                              IfElseFunction::ValueTypesMatchConstraint()),
+        NestedIfElseExec::Exec);
     kernel.null_handling = NullHandling::COMPUTED_NO_PREALLOCATE;
     kernel.mem_allocation = MemAllocation::NO_PREALLOCATE;
     kernel.can_write_into_slices = false;

--- a/cpp/src/arrow/compute/kernels/scalar_if_else.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else.cc
@@ -1242,6 +1242,18 @@ struct ResolveIfElseExec<NullType, AllocateMem> {
 struct IfElseFunction : ScalarFunction {
   using ScalarFunction::ScalarFunction;
 
+  static std::shared_ptr<MatchConstraint> DecimalMatchConstraint() {
+    static auto constraint =
+        MatchConstraint::Make([](const std::vector<TypeHolder>& types) -> bool {
+          DCHECK_EQ(types.size(), 3);
+          DCHECK_EQ(types[0].id(), Type::BOOL);
+          DCHECK(is_decimal(types[1].id()));
+          DCHECK(is_decimal(types[2].id()));
+          return types[1] == types[2];
+        });
+    return constraint;
+  }
+
   Result<const Kernel*> DispatchBest(std::vector<TypeHolder>* types) const override {
     RETURN_NOT_OK(CheckArity(types->size()));
 
@@ -1343,8 +1355,14 @@ void AddBinaryIfElseKernels(const std::shared_ptr<IfElseFunction>& scalar_functi
 template <typename T>
 void AddFixedWidthIfElseKernel(const std::shared_ptr<IfElseFunction>& scalar_function) {
   auto type_id = T::type_id;
-  ScalarKernel kernel({boolean(), InputType(type_id), InputType(type_id)}, LastType,
-                      ResolveIfElseExec<T, /*AllocateMem=*/std::false_type>::Exec);
+  std::shared_ptr<MatchConstraint> constraint = nullptr;
+  if (is_decimal(type_id)) {
+    constraint = IfElseFunction::DecimalMatchConstraint();
+  }
+  ScalarKernel kernel(
+      KernelSignature::Make({boolean(), InputType(type_id), InputType(type_id)}, LastType,
+                            /*is_varargs=*/false, std::move(constraint)),
+      ResolveIfElseExec<T, /*AllocateMem=*/std::false_type>::Exec);
   kernel.null_handling = NullHandling::COMPUTED_PREALLOCATE;
   kernel.mem_allocation = MemAllocation::PREALLOCATE;
   kernel.can_write_into_slices = true;

--- a/cpp/src/arrow/compute/kernels/scalar_if_else.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else.cc
@@ -1243,12 +1243,8 @@ struct IfElseFunction : ScalarFunction {
   using ScalarFunction::ScalarFunction;
 
   static std::shared_ptr<MatchConstraint> ValueTypesMatchConstraint() {
-    static auto constraint =
-        MatchConstraint::Make([](const std::vector<TypeHolder>& types) -> bool {
-          DCHECK_EQ(types.size(), 3);
-          DCHECK_EQ(types[0].id(), Type::BOOL);
-          return types[1] == types[2];
-        });
+    static auto constraint = MatchConstraint::Make(
+        [](const std::vector<TypeHolder>& types) { return types[1] == types[2]; });
     return constraint;
   }
 
@@ -1343,13 +1339,10 @@ void AddBinaryIfElseKernels(const std::shared_ptr<IfElseFunction>& scalar_functi
 template <typename T>
 void AddFixedWidthIfElseKernel(const std::shared_ptr<IfElseFunction>& scalar_function) {
   auto type_id = T::type_id;
-  std::shared_ptr<MatchConstraint> constraint = nullptr;
-  if (!TypeTraits<T>::is_parameter_free) {
-    constraint = IfElseFunction::ValueTypesMatchConstraint();
-  }
   ScalarKernel kernel(
       KernelSignature::Make({boolean(), InputType(type_id), InputType(type_id)}, LastType,
-                            /*is_varargs=*/false, std::move(constraint)),
+                            /*is_varargs=*/false,
+                            IfElseFunction::ValueTypesMatchConstraint()),
       ResolveIfElseExec<T, /*AllocateMem=*/std::false_type>::Exec);
   kernel.null_handling = NullHandling::COMPUTED_PREALLOCATE;
   kernel.mem_allocation = MemAllocation::PREALLOCATE;

--- a/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
@@ -966,9 +966,9 @@ TEST_F(TestIfElseKernel, ParameterizedTypes) {
   auto type0 = fixed_size_binary(4);
   auto type1 = fixed_size_binary(5);
   EXPECT_RAISES_WITH_MESSAGE_THAT(
-      TypeError,
-      ::testing::HasSubstr("All types must be compatible, expected: "
-                           "fixed_size_binary[4], but got: fixed_size_binary[5]"),
+      NotImplemented,
+      ::testing::HasSubstr("Function 'if_else' has no kernel matching input types "
+                           "(bool, fixed_size_binary[4], fixed_size_binary[5])"),
       CallFunction("if_else", {cond, ArrayFromJSON(type0, R"(["aaaa"])"),
                                ArrayFromJSON(type1, R"(["aaaaa"])")}));
 
@@ -977,27 +977,30 @@ TEST_F(TestIfElseKernel, ParameterizedTypes) {
   type0 = struct_({field("a", int32())});
   type1 = struct_({field("a", int64())});
   EXPECT_RAISES_WITH_MESSAGE_THAT(
-      TypeError,
-      ::testing::HasSubstr("All types must be compatible, expected: struct<a: int32>, "
-                           "but got: struct<a: int64>"),
+      NotImplemented,
+      ::testing::HasSubstr(
+          "Function 'if_else' has no kernel matching input types "
+          "(bool, struct<a: int32>, struct<a: int64>)"),
       CallFunction("if_else",
                    {cond, ArrayFromJSON(type0, "[[0]]"), ArrayFromJSON(type1, "[[0]]")}));
 
   type0 = dense_union({field("a", int32())});
   type1 = dense_union({field("a", int64())});
   EXPECT_RAISES_WITH_MESSAGE_THAT(
-      TypeError,
-      ::testing::HasSubstr("All types must be compatible, expected: dense_union<a: "
-                           "int32=0>, but got: dense_union<a: int64=0>"),
+      NotImplemented,
+      ::testing::HasSubstr(
+          "Function 'if_else' has no kernel matching input types "
+          "(bool, dense_union<a: int32=0>, dense_union<a: int64=0>)"),
       CallFunction("if_else", {cond, ArrayFromJSON(type0, "[[0, -1]]"),
                                ArrayFromJSON(type1, "[[0, -1]]")}));
 
   type0 = list(int16());
   type1 = list(int32());
   EXPECT_RAISES_WITH_MESSAGE_THAT(
-      TypeError,
-      ::testing::HasSubstr("All types must be compatible, expected: list<item: int16>, "
-                           "but got: list<item: int32>"),
+      NotImplemented,
+      ::testing::HasSubstr(
+          "Function 'if_else' has no kernel matching input types "
+          "(bool, list<item: int16>, list<item: int32>)"),
       CallFunction("if_else",
                    {cond, ArrayFromJSON(type0, "[[0]]"), ArrayFromJSON(type1, "[[0]]")}));
 
@@ -1011,19 +1014,21 @@ TEST_F(TestIfElseKernel, ParameterizedTypes) {
   type0 = timestamp(TimeUnit::SECOND);
   type1 = timestamp(TimeUnit::SECOND, "America/Phoenix");
   EXPECT_RAISES_WITH_MESSAGE_THAT(
-      TypeError,
-      ::testing::HasSubstr("All types must be compatible, expected: timestamp[s], "
-                           "but got: timestamp[s, tz=America/Phoenix]"),
+      NotImplemented,
+      ::testing::HasSubstr("Function 'if_else' has no kernel matching input types "
+                           "(bool, timestamp[s], "
+                           "timestamp[s, tz=America/Phoenix])"),
       CallFunction("if_else",
                    {cond, ArrayFromJSON(type0, "[0]"), ArrayFromJSON(type1, "[1]")}));
 
   type0 = timestamp(TimeUnit::SECOND, "America/New_York");
   type1 = timestamp(TimeUnit::SECOND, "America/Phoenix");
   EXPECT_RAISES_WITH_MESSAGE_THAT(
-      TypeError,
+      NotImplemented,
       ::testing::HasSubstr(
-          "All types must be compatible, expected: timestamp[s, tz=America/New_York], "
-          "but got: timestamp[s, tz=America/Phoenix]"),
+          "Function 'if_else' has no kernel matching input types "
+          "(bool, timestamp[s, tz=America/New_York], "
+          "timestamp[s, tz=America/Phoenix])"),
       CallFunction("if_else",
                    {cond, ArrayFromJSON(type0, "[0]"), ArrayFromJSON(type1, "[1]")}));
 

--- a/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
@@ -515,6 +515,12 @@ TEST_F(TestIfElseKernel, IfElseDispatchBest) {
                     {boolean(), date64(), date64()});
   CheckDispatchBest(name, {boolean(), date32(), date32()},
                     {boolean(), date32(), date32()});
+
+  ASSERT_RAISES(NotImplemented,
+                function->DispatchExact(
+                    {boolean(), decimal128(3, 2), decimal128(4, 3)}));
+  CheckDispatchBest(name, {boolean(), decimal128(3, 2), decimal128(4, 3)},
+                    {boolean(), decimal128(4, 3), decimal128(4, 3)});
 }
 
 template <typename Type>


### PR DESCRIPTION
## Summary

- add a decimal match constraint to `if_else` kernels
- make mixed decimal inputs miss `DispatchExact` and fall back to `DispatchBest` normalization
- add regression coverage for the new exact-match behavior

## Why

This refactors part of `if_else` dispatch so that the exact-match acceptance rule for decimal kernels is expressed at the kernel signature layer rather than only implied by function-level dispatch behavior.

## Validation

- built `arrow-compute-scalar-if-else-test`
- `TestIfElseKernel.IfElseDispatchBest` passes
