### PR TITLE
[C++][Compute] Add decimal dispatch regression tests

### DIFF
--- a/cpp/src/arrow/compute/expression_test.cc
+++ b/cpp/src/arrow/compute/expression_test.cc
@@ -938,6 +938,45 @@ TEST(Expression, BindWithImplicitCastsForCaseWhenOnDecimal) {
                 /*bound_out=*/nullptr, *exciting_schema);
 }
 
+TEST(Expression, BindWithImplicitCastsForIfElseOnDecimal) {
+  auto schema = arrow::schema({field("cond", boolean()),
+                               field("dec128_3_2", decimal128(3, 2)),
+                               field("dec128_4_3", decimal128(4, 3))});
+
+  ExpectBindsTo(
+      call("if_else",
+           {field_ref("cond"), field_ref("dec128_3_2"), field_ref("dec128_4_3")}),
+      call("if_else",
+           {field_ref("cond"), cast(field_ref("dec128_3_2"), decimal128(4, 3)),
+            field_ref("dec128_4_3")}),
+      /*bound_out=*/nullptr, *schema);
+}
+
+TEST(Expression, BindWithImplicitCastsForCoalesceOnDecimal) {
+  auto schema = arrow::schema({field("dec128_3_2", decimal128(3, 2)),
+                               field("dec128_4_3", decimal128(4, 3))});
+
+  ExpectBindsTo(
+      call("coalesce", {field_ref("dec128_3_2"), field_ref("dec128_4_3")}),
+      call("coalesce", {cast(field_ref("dec128_3_2"), decimal128(4, 3)),
+                        field_ref("dec128_4_3")}),
+      /*bound_out=*/nullptr, *schema);
+}
+
+TEST(Expression, BindWithImplicitCastsForChooseOnDecimal) {
+  auto schema = arrow::schema({field("indices", int64()),
+                               field("dec128_3_2", decimal128(3, 2)),
+                               field("dec128_4_3", decimal128(4, 3))});
+
+  ExpectBindsTo(
+      call("choose",
+           {field_ref("indices"), field_ref("dec128_3_2"), field_ref("dec128_4_3")}),
+      call("choose",
+           {field_ref("indices"), cast(field_ref("dec128_3_2"), decimal128(4, 3)),
+            field_ref("dec128_4_3")}),
+      /*bound_out=*/nullptr, *schema);
+}
+
 TEST(Expression, BindNestedCall) {
   auto expr = add(field_ref("a"),
                   call("subtract", {call("multiply", {field_ref("b"), field_ref("c")}),

--- a/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
@@ -3651,6 +3651,8 @@ TEST(TestCoalesce, DispatchBest) {
                     {large_binary(), large_binary()});
   CheckDispatchBest("coalesce", {int32(), decimal128(3, 2)},
                     {decimal128(12, 2), decimal128(12, 2)});
+  CheckDispatchBest("coalesce", {decimal128(3, 2), decimal128(4, 3)},
+                    {decimal128(4, 3), decimal128(4, 3)});
   CheckDispatchBest("coalesce", {float32(), decimal128(3, 2)}, {float64(), float64()});
   CheckDispatchBest("coalesce", {decimal128(3, 2), decimal256(3, 2)},
                     {decimal256(3, 2), decimal256(3, 2)});
@@ -3910,6 +3912,8 @@ TEST(TestChooseKernel, DispatchBest) {
   // Other arguments promoted separately from index
   EXPECT_EQ((std::vector<TypeHolder>{int64(), int32(), int32()}),
             Check({int8(), int32(), uint8()}));
+  EXPECT_EQ((std::vector<TypeHolder>{int64(), decimal128(4, 3), decimal128(4, 3)}),
+            Check({int8(), decimal128(3, 2), decimal128(4, 3)}));
 }
 
 TEST(TestChooseKernel, Errors) {


### PR DESCRIPTION
Adds focused regression/validation cases for decimal dispatch behavior around match constraints and expression binding.

What changed:
- Adds expression bind cases for decimal `if_else`, `coalesce`, and `choose`.
- Adds dispatch-level decimal cases for `coalesce` and `choose`.

Baseline:
- This PR targets `codex/if-else-match-constraint` inside the fork repo so the diff only contains the test cases, not the existing match-constraint implementation.

Validation:
- `git diff --check` passes.
- `.build-choose-test/release/arrow-compute-expression-test --gtest_filter=Expression.BindWithImplicitCastsForIfElseOnDecimal:Expression.BindWithImplicitCastsForCoalesceOnDecimal:Expression.BindWithImplicitCastsForChooseOnDecimal` currently has 1 pass and 2 expected failures: `coalesce` and `choose` expression binding do not insert the decimal cast.
- `.build-choose-test/release/arrow-compute-scalar-if-else-test --gtest_filter=TestCoalesce.DispatchBest:TestChooseKernel.DispatchBest` currently has 1 pass and 1 expected failure: `choose` DispatchBest does not normalize decimal value args yet.