### PR TITLE
[C++][Compute] Normalize decimal value arguments in choose DispatchBest

### DIFF
--- a/cpp/src/arrow/compute/expression_test.cc
+++ b/cpp/src/arrow/compute/expression_test.cc
@@ -938,6 +938,20 @@ TEST(Expression, BindWithImplicitCastsForCaseWhenOnDecimal) {
                 /*bound_out=*/nullptr, *exciting_schema);
 }
 
+TEST(Expression, BindWithImplicitCastsForChooseOnDecimal) {
+  auto schema = arrow::schema({field("indices", int64()),
+                               field("dec128_3_2", decimal128(3, 2)),
+                               field("dec128_4_3", decimal128(4, 3))});
+
+  ExpectBindsTo(
+      call("choose",
+           {field_ref("indices"), field_ref("dec128_3_2"), field_ref("dec128_4_3")}),
+      call("choose",
+           {field_ref("indices"), cast(field_ref("dec128_3_2"), decimal128(4, 3)),
+            field_ref("dec128_4_3")}),
+      /*bound_out=*/nullptr, *schema);
+}
+
 TEST(Expression, BindNestedCall) {
   auto expr = add(field_ref("a"),
                   call("subtract", {call("multiply", {field_ref("b"), field_ref("c")}),

--- a/cpp/src/arrow/compute/kernels/scalar_if_else.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else.cc
@@ -2752,10 +2752,27 @@ struct ChooseFunction : ScalarFunction {
         *it = type;
       }
     }
+    if (HasDecimal(*types)) {
+      RETURN_NOT_OK(CastDecimalArgs(types->data() + 1, types->size() - 1));
+    }
     if (auto kernel = DispatchExactImpl(this, {types->front(), types->back()})) {
       return kernel;
     }
     return arrow::compute::detail::NoMatchingKernel(this, *types);
+  }
+
+  static std::shared_ptr<MatchConstraint> DecimalMatchConstraint() {
+    static auto constraint =
+        MatchConstraint::Make([](const std::vector<TypeHolder>& types) -> bool {
+          DCHECK_GE(types.size(), 2);
+          DCHECK(std::all_of(types.begin() + 1, types.end(), [](const TypeHolder& type) {
+            return is_decimal(type.id());
+          }));
+          return std::all_of(
+              types.begin() + 2, types.end(),
+              [&types](const TypeHolder& type) { return type == types[1]; });
+        });
+    return constraint;
   }
 };
 
@@ -2852,9 +2869,10 @@ void AddNestedCoalesceKernels(const std::shared_ptr<ScalarFunction>& scalar_func
 }
 
 void AddChooseKernel(const std::shared_ptr<ScalarFunction>& scalar_function,
-                     detail::GetTypeId get_id, ArrayKernelExec exec) {
+                     detail::GetTypeId get_id, ArrayKernelExec exec,
+                     std::shared_ptr<MatchConstraint> constraint = nullptr) {
   ScalarKernel kernel(KernelSignature::Make({Type::INT64, InputType(get_id.id)}, LastType,
-                                            /*is_varargs=*/true),
+                                            /*is_varargs=*/true, std::move(constraint)),
                       exec);
   kernel.null_handling = NullHandling::COMPUTED_PREALLOCATE;
   kernel.mem_allocation = MemAllocation::PREALLOCATE;
@@ -2975,8 +2993,10 @@ void RegisterScalarIfElse(FunctionRegistry* registry) {
     AddPrimitiveChooseKernels(func, {boolean(), null(), float16()});
     AddChooseKernel(func, Type::FIXED_SIZE_BINARY,
                     ChooseFunctor<FixedSizeBinaryType>::Exec);
-    AddChooseKernel(func, Type::DECIMAL128, ChooseFunctor<FixedSizeBinaryType>::Exec);
-    AddChooseKernel(func, Type::DECIMAL256, ChooseFunctor<FixedSizeBinaryType>::Exec);
+    AddChooseKernel(func, Type::DECIMAL128, ChooseFunctor<FixedSizeBinaryType>::Exec,
+                    ChooseFunction::DecimalMatchConstraint());
+    AddChooseKernel(func, Type::DECIMAL256, ChooseFunctor<FixedSizeBinaryType>::Exec,
+                    ChooseFunction::DecimalMatchConstraint());
     for (const auto& ty : BaseBinaryTypes()) {
       AddChooseKernel(func, ty, GenerateTypeAgnosticVarBinaryBase<ChooseFunctor>(ty));
     }

--- a/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
@@ -3899,6 +3899,8 @@ TEST(TestChooseKernel, DispatchBest) {
   // Other arguments promoted separately from index
   EXPECT_EQ((std::vector<TypeHolder>{int64(), int32(), int32()}),
             Check({int8(), int32(), uint8()}));
+  EXPECT_EQ((std::vector<TypeHolder>{int64(), decimal128(4, 3), decimal128(4, 3)}),
+            Check({int8(), decimal128(3, 2), decimal128(4, 3)}));
 }
 
 TEST(TestChooseKernel, Errors) {


### PR DESCRIPTION
## Summary
- normalize decimal value arguments in `choose` `DispatchBest` after index promotion
- require decimal `choose` exact matches to already share the same decimal type so binding falls back to `DispatchBest` when rescaling is needed
- add focused dispatch and expression-binding regression coverage for mixed-scale decimal `choose` calls

## Root cause
`choose` was missing the decimal normalization step that `if_else`, `case_when`, and `coalesce` already apply on their best-dispatch path. Separately, the decimal varargs kernels for `choose` were permissive enough to satisfy exact dispatch for mixed-scale decimal arguments, which let expression binding bypass `DispatchBest` entirely and keep mismatched decimal value types.

## What changed
After promoting the index argument to `int64`, `ChooseFunction::DispatchBest` now runs decimal normalization across the value arguments before selecting the kernel. The decimal `choose` kernels also now carry a match constraint that only allows exact dispatch when all decimal value arguments already have the same type, so expression binding inserts the expected casts instead of short-circuiting.

## Testing
- `arrow-compute-expression-test --gtest_filter='Expression.BindWithImplicitCastsForChooseOnDecimal'`
- `arrow-compute-scalar-if-else-test --gtest_filter='TestChooseKernel.DispatchBest'`
- `arrow-compute-scalar-if-else-test --gtest_filter='TestChoose.*:TestChooseKernel.*'`
