### PR TITLE
[C++][Compute] Tighten if_else exact dispatch for parameterized value types

### DIFF
--- a/cpp/src/arrow/compute/expression_test.cc
+++ b/cpp/src/arrow/compute/expression_test.cc
@@ -938,6 +938,28 @@ TEST(Expression, BindWithImplicitCastsForCaseWhenOnDecimal) {
                 /*bound_out=*/nullptr, *exciting_schema);
 }
 
+TEST(Expression, BindWithImplicitCastsForIfElseOnDecimal) {
+  auto exciting_schema = schema({field("cond", boolean()),
+                                 field("dec128_3_2", decimal128(3, 2)),
+                                 field("dec128_4_3", decimal128(4, 3)),
+                                 field("dec256_3_2", decimal256(3, 2))});
+
+  ExpectBindsTo(
+      call("if_else",
+           {field_ref("cond"), field_ref("dec128_3_2"), field_ref("dec128_4_3")}),
+      call("if_else",
+           {field_ref("cond"), cast(field_ref("dec128_3_2"), decimal128(4, 3)),
+            field_ref("dec128_4_3")}),
+      /*bound_out=*/nullptr, *exciting_schema);
+  ExpectBindsTo(
+      call("if_else",
+           {field_ref("cond"), field_ref("dec128_3_2"), field_ref("dec256_3_2")}),
+      call("if_else",
+           {field_ref("cond"), cast(field_ref("dec128_3_2"), decimal256(3, 2)),
+            field_ref("dec256_3_2")}),
+      /*bound_out=*/nullptr, *exciting_schema);
+}
+
 TEST(Expression, BindNestedCall) {
   auto expr = add(field_ref("a"),
                   call("subtract", {call("multiply", {field_ref("b"), field_ref("c")}),

--- a/cpp/src/arrow/compute/kernels/scalar_if_else.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else.cc
@@ -1285,6 +1285,15 @@ struct IfElseFunction : ScalarFunction {
 
     return arrow::compute::detail::NoMatchingKernel(this, *types);
   }
+
+  static std::shared_ptr<MatchConstraint> ValueTypesMatchConstraint() {
+    static auto constraint =
+        MatchConstraint::Make([](const std::vector<TypeHolder>& types) -> bool {
+          DCHECK_EQ(types.size(), 3);
+          return types[1] == types[2];
+        });
+    return constraint;
+  }
 };
 
 void AddNullIfElseKernel(const std::shared_ptr<IfElseFunction>& scalar_function) {
@@ -1314,6 +1323,8 @@ void AddPrimitiveIfElseKernels(const std::shared_ptr<ScalarFunction>& scalar_fun
     } else {
       sig = KernelSignature::Make({boolean(), type, type}, type);
     }
+    sig = KernelSignature::Make(sig->in_types(), sig->out_type(), sig->is_varargs(),
+                                IfElseFunction::ValueTypesMatchConstraint());
     ScalarKernel kernel(std::move(sig), exec);
     kernel.null_handling = NullHandling::COMPUTED_PREALLOCATE;
     kernel.mem_allocation = MemAllocation::PREALLOCATE;
@@ -1331,7 +1342,10 @@ void AddBinaryIfElseKernels(const std::shared_ptr<IfElseFunction>& scalar_functi
                                                     /*AllocateMem=*/std::true_type>(
             *type);
     // cond array needs to be boolean always
-    ScalarKernel kernel({boolean(), type, type}, type, exec);
+    ScalarKernel kernel(
+        KernelSignature::Make({boolean(), type, type}, type, /*is_varargs=*/false,
+                              IfElseFunction::ValueTypesMatchConstraint()),
+        exec);
     kernel.null_handling = NullHandling::COMPUTED_NO_PREALLOCATE;
     kernel.mem_allocation = MemAllocation::NO_PREALLOCATE;
     kernel.can_write_into_slices = false;
@@ -1343,8 +1357,11 @@ void AddBinaryIfElseKernels(const std::shared_ptr<IfElseFunction>& scalar_functi
 template <typename T>
 void AddFixedWidthIfElseKernel(const std::shared_ptr<IfElseFunction>& scalar_function) {
   auto type_id = T::type_id;
-  ScalarKernel kernel({boolean(), InputType(type_id), InputType(type_id)}, LastType,
-                      ResolveIfElseExec<T, /*AllocateMem=*/std::false_type>::Exec);
+  ScalarKernel kernel(
+      KernelSignature::Make({boolean(), InputType(type_id), InputType(type_id)}, LastType,
+                            /*is_varargs=*/false,
+                            IfElseFunction::ValueTypesMatchConstraint()),
+      ResolveIfElseExec<T, /*AllocateMem=*/std::false_type>::Exec);
   kernel.null_handling = NullHandling::COMPUTED_PREALLOCATE;
   kernel.mem_allocation = MemAllocation::PREALLOCATE;
   kernel.can_write_into_slices = true;
@@ -1357,8 +1374,11 @@ void AddNestedIfElseKernels(const std::shared_ptr<IfElseFunction>& scalar_functi
        {Type::LIST, Type::LARGE_LIST, Type::LIST_VIEW, Type::LARGE_LIST_VIEW,
         Type::FIXED_SIZE_LIST, Type::MAP, Type::STRUCT, Type::DENSE_UNION,
         Type::SPARSE_UNION, Type::DICTIONARY}) {
-    ScalarKernel kernel({boolean(), InputType(type_id), InputType(type_id)}, LastType,
-                        NestedIfElseExec::Exec);
+    ScalarKernel kernel(
+        KernelSignature::Make({boolean(), InputType(type_id), InputType(type_id)},
+                              LastType, /*is_varargs=*/false,
+                              IfElseFunction::ValueTypesMatchConstraint()),
+        NestedIfElseExec::Exec);
     kernel.null_handling = NullHandling::COMPUTED_NO_PREALLOCATE;
     kernel.mem_allocation = MemAllocation::NO_PREALLOCATE;
     kernel.can_write_into_slices = false;

--- a/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
@@ -500,6 +500,8 @@ TEST_F(TestIfElseKernel, IfElseDispatchBest) {
                     {boolean(), float32(), float32()});
   CheckDispatchBest(name, {boolean(), float64(), int32()},
                     {boolean(), float64(), float64()});
+  CheckDispatchBest(name, {boolean(), decimal128(3, 2), decimal128(4, 3)},
+                    {boolean(), decimal128(4, 3), decimal128(4, 3)});
 
   CheckDispatchBest(name, {null(), uint8(), int8()}, {boolean(), int16(), int16()});
 
@@ -515,6 +517,21 @@ TEST_F(TestIfElseKernel, IfElseDispatchBest) {
                     {boolean(), date64(), date64()});
   CheckDispatchBest(name, {boolean(), date32(), date32()},
                     {boolean(), date32(), date32()});
+}
+
+TEST_F(TestIfElseKernel, IfElseDispatchExact) {
+  CheckDispatchExact("if_else", {boolean(), decimal128(3, 2), decimal128(3, 2)});
+  CheckDispatchExactFails("if_else",
+                          {boolean(), decimal128(3, 2), decimal128(4, 3)});
+  CheckDispatchExactFails(
+      "if_else",
+      {boolean(), timestamp(TimeUnit::SECOND), timestamp(TimeUnit::SECOND, "UTC")});
+  CheckDispatchExactFails("if_else",
+                          {boolean(), fixed_size_binary(3), fixed_size_binary(4)});
+  CheckDispatchExactFails("if_else", {boolean(), list(int32()), list(int64())});
+  CheckDispatchExactFails("if_else",
+                          {boolean(), dictionary(int8(), int32()),
+                           dictionary(int8(), int64())});
 }
 
 template <typename Type>


### PR DESCRIPTION
## Summary

- tighten `if_else` exact dispatch so the value operands must fully match as `DataType`s before an exact kernel can be selected
- keep `DispatchBest` responsible for decimal normalization / cast insertion instead of letting broad `type_id` matches short-circuit that path
- add targeted dispatch and expression-binding regressions for decimal casts plus exact-dispatch rejects for timestamp timezone, fixed-size binary, nested, and dictionary mismatches

## Root cause

`if_else` registered several exact kernels with signatures that only matched the value operands by `type_id` (for example decimals, fixed-size binary, nested, dictionary, and timestamp unit matchers). That let exact dispatch succeed for parameterized value types that were not actually type-equal, which could bypass the normalization and cast-insertion logic that lives in `DispatchBest` and expression binding.

## What changed

- add a shared `MatchConstraint` for `if_else` kernels that requires `then` and `else` to have the same full `DataType` during exact dispatch
- apply that constraint to the registered primitive, binary, fixed-width, and nested `if_else` kernels so exact dispatch no longer accepts broader parameterized matches
- add decimal-focused `DispatchBest` and expression binding tests to confirm the cast path still runs when exact dispatch is rejected

## Validation

- `./build/debug/arrow-compute-scalar-if-else-test --gtest_filter=TestIfElseKernel.IfElseDispatchBest:TestIfElseKernel.IfElseDispatchExact`
- `./build/debug/arrow-compute-expression-test --gtest_filter=Expression.BindWithImplicitCastsForIfElseOnDecimal`
