### PR TITLE
[codex] MINOR: [CI] Add Acero CODEOWNER

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -55,6 +55,7 @@ compose.yaml @assignUser @jonkeane @kou @raulcd
 
 ## C++
 /cpp/src/arrow/ @pitrou
+/cpp/src/arrow/acero @zanmato1984
 /cpp/src/arrow/adapters/orc @wgtmac
 /cpp/src/arrow/flight/ @lidavidm
 /cpp/src/gandiva @dmitry-chirkov-dremio @lriggs @akravchukdremio @xxlaykxx


### PR DESCRIPTION
Follow-up to apache/arrow#50420.

Adds @zanmato1984 as an Acero CODEOWNER.

No tests; CODEOWNERS-only change.