### PR TITLE
[codex] Preserve fast grouper key order

### DIFF
--- a/cpp/src/arrow/compute/key_map_internal.cc
+++ b/cpp/src/arrow/compute/key_map_internal.cc
@@ -508,8 +508,8 @@ void SwissTable::find(const int num_keys, const uint32_t* hashes,
 // call to follow a call to find() method, which would only pass on new keys that were
 // not present in the hash table.
 //
-// Run a single round of slot search - comparison or insert - filter unprocessed.
-// Update selection vector to reflect which items have been processed.
+// Probe selected keys, compare stamp matches, then commit new keys in input order.
+// Update selection vector to keep items that were not processed due to resize.
 // Ids in selection vector do not have to be sorted.
 //
 Status SwissTable::map_new_keys_helper(
@@ -529,46 +529,25 @@ Status SwissTable::map_new_keys_helper(
   auto match_bitvector_buf = util::TempVectorHolder<uint8_t>(
       temp_stack, static_cast<uint32_t>(num_bytes_for_bits));
   uint8_t* match_bitvector = match_bitvector_buf.mutable_data();
-  memset(match_bitvector, 0xff, num_bytes_for_bits);
+  memset(match_bitvector, 0, num_bytes_for_bits);
 
   // Check the alignment of the input selection vector
   ARROW_DCHECK((reinterpret_cast<uint64_t>(inout_selection) & 1) == 0);
 
-  uint32_t num_inserted_new = 0;
-  bool has_pending_match = false;
-  uint32_t num_processed;
-  for (num_processed = 0; num_processed < *inout_num_selected; ++num_processed) {
+  auto id_to_pos_buffer =
+      util::TempVectorHolder<uint16_t>(temp_stack, 1 << log_minibatch_);
+  uint16_t* id_to_pos = id_to_pos_buffer.mutable_data();
+
+  uint32_t num_processed = *inout_num_selected;
+  for (uint32_t i = 0; i < num_processed; ++i) {
     // row id in original batch
-    int id = inout_selection[num_processed];
+    int id = inout_selection[i];
+    id_to_pos[id] = static_cast<uint16_t>(i);
     bool match_found =
         find_next_stamp_match(hashes[id], inout_next_slot_ids[id],
                               &inout_next_slot_ids[id], &out_group_ids[id]);
     if (match_found) {
-      has_pending_match = true;
-      continue;
-    }
-
-    // Do not let later insertions overtake an earlier key whose stamp match still
-    // needs an equality comparison. If the pending match turns out to be a false
-    // positive, it must get its new group id before later input rows.
-    if (has_pending_match) {
-      break;
-    }
-
-    // If we reach the empty slot we insert key for new group
-    //
-    out_group_ids[id] = num_inserted_ + num_inserted_new;
-    insert_into_empty_slot(inout_next_slot_ids[id], hashes[id], out_group_ids[id]);
-    this->hashes()[inout_next_slot_ids[id]] = hashes[id];
-    ::arrow::bit_util::ClearBit(match_bitvector, num_processed);
-    ++num_inserted_new;
-
-    // We need to break processing and have the caller of this function resize hash
-    // table if we reach the limit of the number of groups present.
-    //
-    if (num_inserted_ + num_inserted_new == num_groups_limit) {
-      ++num_processed;
-      break;
+      ::arrow::bit_util::SetBit(match_bitvector, i);
     }
   }
 
@@ -577,30 +556,92 @@ Status SwissTable::map_new_keys_helper(
   uint16_t* temp_ids = temp_ids_buffer.mutable_data();
   int num_temp_ids = 0;
 
-  // Copy keys for newly inserted rows using callback
-  //
-  util::bit_util::bits_filter_indexes(0, hardware_flags_, num_processed, match_bitvector,
-                                      inout_selection, &num_temp_ids, temp_ids);
-  ARROW_DCHECK(static_cast<int>(num_inserted_new) == num_temp_ids);
-  RETURN_NOT_OK(append_impl(num_inserted_new, temp_ids, callback_ctx));
-  num_inserted_ += num_inserted_new;
-
-  // Evaluate comparisons and append ids of rows that failed it to the non-match set.
+  // Evaluate comparisons for rows with a matching stamp. Rows that fail comparison
+  // become new-key candidates and must be committed in the original input order.
   util::bit_util::bits_filter_indexes(1, hardware_flags_, num_processed, match_bitvector,
                                       inout_selection, &num_temp_ids, temp_ids);
   run_comparisons(num_temp_ids, temp_ids, nullptr, out_group_ids, &num_temp_ids, temp_ids,
                   equal_impl, callback_ctx);
+  for (int i = 0; i < num_temp_ids; ++i) {
+    ::arrow::bit_util::ClearBit(match_bitvector, id_to_pos[temp_ids[i]]);
+  }
 
-  if (num_temp_ids > 0) {
-    memcpy(inout_selection, temp_ids, sizeof(uint16_t) * num_temp_ids);
+  auto append_ids_buffer =
+      util::TempVectorHolder<uint16_t>(temp_stack, *inout_num_selected);
+  uint16_t* append_ids = append_ids_buffer.mutable_data();
+  uint32_t num_pending_appends = 0;
+
+  auto flush_appends = [&]() -> Status {
+    if (num_pending_appends == 0) {
+      return Status::OK();
+    }
+    RETURN_NOT_OK(append_impl(num_pending_appends, append_ids, callback_ctx));
+    num_inserted_ += num_pending_appends;
+    num_pending_appends = 0;
+    return Status::OK();
+  };
+
+  const int num_groupid_bits = num_groupid_bits_from_log_blocks(log_blocks_);
+  const int num_block_bytes = num_block_bytes_from_num_groupid_bits(num_groupid_bits);
+  auto slot_is_empty = [&](uint32_t slot_id) {
+    const uint8_t* blockbase = block_data(slot_id >> kLogSlotsPerBlock, num_block_bytes);
+    return blockbase[kMaxLocalSlot - (slot_id & kLocalSlotMask)] == 0x80;
+  };
+
+  uint32_t num_committed = 0;
+  bool reached_capacity = false;
+  for (; num_committed < num_processed; ++num_committed) {
+    if (::arrow::bit_util::GetBit(match_bitvector, num_committed)) {
+      continue;
+    }
+
+    int id = inout_selection[num_committed];
+    for (;;) {
+      bool match_found = false;
+      if (!slot_is_empty(inout_next_slot_ids[id])) {
+        match_found =
+            find_next_stamp_match(hashes[id], inout_next_slot_ids[id],
+                                  &inout_next_slot_ids[id], &out_group_ids[id]);
+      }
+      if (!match_found) {
+        // If we reach the empty slot we insert key for new group.
+        out_group_ids[id] = num_inserted_ + num_pending_appends;
+        insert_into_empty_slot(inout_next_slot_ids[id], hashes[id], out_group_ids[id]);
+        this->hashes()[inout_next_slot_ids[id]] = hashes[id];
+        append_ids[num_pending_appends++] = static_cast<uint16_t>(id);
+
+        // We need to break processing and have the caller of this function resize hash
+        // table if we reach the limit of the number of groups present.
+        if (num_inserted_ + num_pending_appends == num_groups_limit) {
+          ++num_committed;
+          reached_capacity = true;
+        }
+        break;
+      }
+
+      // A match may point at a key inserted earlier in this commit pass. Make its row
+      // visible before running equality comparison.
+      RETURN_NOT_OK(flush_appends());
+      uint16_t temp_id = static_cast<uint16_t>(id);
+      int num_not_equal;
+      run_comparisons(1, &temp_id, nullptr, out_group_ids, &num_not_equal, &temp_id,
+                      equal_impl, callback_ctx);
+      if (num_not_equal == 0) {
+        break;
+      }
+    }
+
+    if (reached_capacity) {
+      break;
+    }
   }
-  // Append ids of any unprocessed entries if we aborted processing due to the need
-  // to resize.
-  if (num_processed < *inout_num_selected) {
-    memmove(inout_selection + num_temp_ids, inout_selection + num_processed,
-            sizeof(uint16_t) * (*inout_num_selected - num_processed));
+  RETURN_NOT_OK(flush_appends());
+
+  if (num_committed < *inout_num_selected) {
+    memmove(inout_selection, inout_selection + num_committed,
+            sizeof(uint16_t) * (*inout_num_selected - num_committed));
   }
-  *inout_num_selected = num_temp_ids + (*inout_num_selected - num_processed);
+  *inout_num_selected = *inout_num_selected - num_committed;
 
   *out_need_resize = (num_inserted_ == num_groups_limit);
   return Status::OK();

--- a/cpp/src/arrow/compute/key_map_internal.cc
+++ b/cpp/src/arrow/compute/key_map_internal.cc
@@ -533,50 +533,78 @@ Status SwissTable::map_new_keys_helper(
   auto match_bitvector_buf = util::TempVectorHolder<uint8_t>(
       temp_stack, static_cast<uint32_t>(num_bytes_for_bits));
   uint8_t* match_bitvector = match_bitvector_buf.mutable_data();
+  // 中文说明：初始化为 0，表示当前还没有任何行被标记为“候选 match”。
   memset(match_bitvector, 0, num_bytes_for_bits);
   // 中文说明：match_bitvector 标记“找到了候选槽，仍需 equal_impl 确认”的
   // 行；committed_bitvector 标记“已经按输入顺序分配过 group id”的行。
+  // 中文说明：为“已经提交过”的行申请一个 bitset，避免 ordered pass 重复处理。
   auto committed_bitvector_buf = util::TempVectorHolder<uint8_t>(
+      // 中文说明：这个 bitset 和 match_bitvector 覆盖同一批 selection 位置。
       temp_stack, static_cast<uint32_t>(num_bytes_for_bits));
+  // 中文说明：拿到 committed bitset 的可写指针，后面按 position 标记。
   uint8_t* committed_bitvector = committed_bitvector_buf.mutable_data();
+  // 中文说明：初始时没有任何行被提交，所以全部清零。
   memset(committed_bitvector, 0, num_bytes_for_bits);
 
   // Check the alignment of the input selection vector
   ARROW_DCHECK((reinterpret_cast<uint64_t>(inout_selection) & 1) == 0);
 
+  // 中文说明：给每个原始 batch row id 记录它在当前 selection 里的位置。
   auto id_to_pos_buffer =
+      // 中文说明：row id 的最大范围由 minibatch 限制，和旧实现的临时数组一致。
       util::TempVectorHolder<uint16_t>(temp_stack, 1 << log_minibatch_);
+  // 中文说明：后面 equal_impl 返回 row id 后，需要用它反查 selection position。
   uint16_t* id_to_pos = id_to_pos_buffer.mutable_data();
+  // 中文说明：保存本轮准备追加到 rows_ 的 row id，便于批量 append。
   auto append_ids_buffer =
+      // 中文说明：最多只会追加当前 selection 里的这些行，所以容量取 selection 大小。
       util::TempVectorHolder<uint16_t>(temp_stack, *inout_num_selected);
+  // 中文说明：append_impl 需要的是 uint16_t row id 数组。
   uint16_t* append_ids = append_ids_buffer.mutable_data();
+  // 中文说明：记录 append_ids 里已经攒了多少个待追加 row。
   uint32_t num_pending_appends = 0;
 
   // 中文说明：新 key 先写入哈希表元数据，但真正把 row 内容追加到 rows_
   // 里可以批量做。只有当后续比较需要“看见”这些新 row 时，才 flush。
+  // 中文说明：定义一个局部 flush 函数，统一处理“批量追加并推进 num_inserted_”。
   auto flush_appends = [&]() -> Status {
+    // 中文说明：没有待追加 row 时直接返回，避免空 append。
     if (num_pending_appends == 0) {
+      // 中文说明：空 flush 是正常路径，返回 OK。
       return Status::OK();
     }
+    // 中文说明：把 pending row 真正复制到 rows_，让后续比较能读到 key 内容。
     RETURN_NOT_OK(append_impl(num_pending_appends, append_ids, callback_ctx));
+    // 中文说明：这些 row 已经成为正式 group，所以全局 inserted 计数前移。
     num_inserted_ += num_pending_appends;
+    // 中文说明：清空 pending 数量，后续可以复用 append_ids 缓冲。
     num_pending_appends = 0;
+    // 中文说明：flush 成功结束。
     return Status::OK();
   };
 
+  // 中文说明：一旦前面出现了待比较的候选 match，后面的新 key 就不能抢先提交。
   bool has_pending_match = false;
+  // 中文说明：记录是否因为达到 resize 阈值而提前停止本轮处理。
   bool reached_capacity = false;
+  // 中文说明：记录已经完成初始探测的 selection 前缀长度。
   uint32_t num_processed = 0;
+  // 中文说明：第一阶段顺序扫描 selection，先区分“候选 match”和“确定新 key”。
   for (; num_processed < *inout_num_selected; ++num_processed) {
     // row id in original batch
     int id = inout_selection[num_processed];
+    // 中文说明：记住 row id 到 selection 位置的映射，便于比较失败后清 match 位。
     id_to_pos[id] = static_cast<uint16_t>(num_processed);
     bool match_found =
         find_next_stamp_match(hashes[id], inout_next_slot_ids[id],
                               &inout_next_slot_ids[id], &out_group_ids[id]);
+    // 中文说明：如果 stamp 命中，先标为候选 match，等 equal_impl 真正比较。
     if (match_found) {
+      // 中文说明：用 selection 位置标记，而不是用原始 row id 标记。
       ::arrow::bit_util::SetBit(match_bitvector, num_processed);
+      // 中文说明：后续新 key 必须等这个候选 match 判定完，不能越过它分配 group id。
       has_pending_match = true;
+      // 中文说明：候选 match 暂时不插入，继续扫描后面的 selection 项。
       continue;
     }
 
@@ -585,20 +613,31 @@ Status SwissTable::map_new_keys_helper(
     // behavior, while later rows still use ordered commit once a pending match appears.
     // 中文说明：在遇到第一个待比较的候选 match 之前，前面的 key 都已经确定
     // 没有被更早的 key 阻塞，所以可以沿用快路径直接插入。
+    // 中文说明：只有没有 pending match 时，当前新 key 才能立即提交。
     if (!has_pending_match) {
+      // 中文说明：group id 等于已有 group 数加上本批还没 flush 的 pending 个数。
       out_group_ids[id] = num_inserted_ + num_pending_appends;
+      // 中文说明：把这个新 group 写进哈希表空槽，后续同 batch 的重复 key 能找到它。
       insert_into_empty_slot(inout_next_slot_ids[id], hashes[id], out_group_ids[id]);
+      // 中文说明：保存完整 hash，供后续 probing / grow 时使用。
       this->hashes()[inout_next_slot_ids[id]] = hashes[id];
+      // 中文说明：row 内容先记录到 pending append，等 flush 时批量复制到 rows_。
       append_ids[num_pending_appends++] = static_cast<uint16_t>(id);
+      // 中文说明：这个 selection 位置已经分配过 group id，ordered pass 需要跳过。
       ::arrow::bit_util::SetBit(committed_bitvector, num_processed);
 
+      // 中文说明：如果 pending append 后达到 resize 阈值，本轮到此为止。
       if (num_inserted_ + num_pending_appends == num_groups_limit) {
+        // 中文说明：当前行已经处理完，所以 num_processed 前移到下一项。
         ++num_processed;
+        // 中文说明：通知后面的逻辑和调用方，这次停止是因为容量上限。
         reached_capacity = true;
+        // 中文说明：跳出第一阶段扫描，剩余 selection 留给扩容后继续处理。
         break;
       }
     }
   }
+  // 中文说明：第一阶段直接插入的 row 要先落到 rows_，后续比较可能依赖它们。
   RETURN_NOT_OK(flush_appends());
 
   auto temp_ids_buffer =
@@ -614,47 +653,72 @@ Status SwissTable::map_new_keys_helper(
                                       inout_selection, &num_temp_ids, temp_ids);
   run_comparisons(num_temp_ids, temp_ids, nullptr, out_group_ids, &num_temp_ids, temp_ids,
                   equal_impl, callback_ctx);
+  // 中文说明：run_comparisons 返回的是“不相等”的 row id，这些要转成新 key 处理。
   for (int i = 0; i < num_temp_ids; ++i) {
+    // 中文说明：比较失败说明并非已有 key，清掉 match 位让 ordered pass 提交它。
     ::arrow::bit_util::ClearBit(match_bitvector, id_to_pos[temp_ids[i]]);
   }
 
+  // 中文说明：计算当前哈希表 block 中 group id 字段占多少 bit。
   const int num_groupid_bits = num_groupid_bits_from_log_blocks(log_blocks_);
+  // 中文说明：由 group id bit 数推导每个 block 的字节数，用于直接读控制字节。
   const int num_block_bytes = num_block_bytes_from_num_groupid_bits(num_groupid_bits);
+  // 中文说明：封装一个判断槽位是否为空的小函数，避免对空槽继续找 match。
   auto slot_is_empty = [&](uint32_t slot_id) {
+    // 中文说明：slot_id 先换算到 block 起始地址。
     const uint8_t* blockbase = block_data(slot_id >> kLogSlotsPerBlock, num_block_bytes);
+    // 中文说明：控制字节 0x80 表示 empty slot。
     return blockbase[kMaxLocalSlot - (slot_id & kLocalSlotMask)] == 0x80;
   };
 
+  // 中文说明：记录 ordered commit pass 已经推进到 selection 的哪个位置。
   uint32_t num_committed = 0;
   // 中文说明：从 selection 的第 0 个位置开始顺序提交，这就是保序的关键。
   // 已经确认匹配旧 key 的行跳过；未匹配的行才按当前位置分配新的 group id。
+  // 中文说明：第二阶段按 selection 物理顺序提交，防止后面的 key 提前拿 group id。
   for (; num_committed < num_processed; ++num_committed) {
+    // 中文说明：已确认匹配或第一阶段已提交的行，都不需要再次分配 group id。
     if (::arrow::bit_util::GetBit(match_bitvector, num_committed) ||
         ::arrow::bit_util::GetBit(committed_bitvector, num_committed)) {
+      // 中文说明：跳过当前位置，继续看下一个 first-seen 顺序位置。
       continue;
     }
 
+    // 中文说明：取出当前 selection 位置对应的原始 batch row id。
     int id = inout_selection[num_committed];
+    // 中文说明：当前 key 可能连续遇到多个 hash stamp 候选，需要循环确认。
     for (;;) {
+      // 中文说明：本轮循环先假设没有找到真正 match。
       bool match_found = false;
+      // 中文说明：如果当前槽已经是空槽，就不需要再调用 find_next_stamp_match。
       if (!slot_is_empty(inout_next_slot_ids[id])) {
+        // 中文说明：沿 probing 链继续找下一个 stamp 相同的候选槽。
         match_found =
             find_next_stamp_match(hashes[id], inout_next_slot_ids[id],
                                   &inout_next_slot_ids[id], &out_group_ids[id]);
       }
+      // 中文说明：没有候选 match 时，当前 key 确认为新 group。
       if (!match_found) {
         // If we reach the empty slot we insert key for new group.
+        // 中文说明：严格在当前 selection 位置分配下一个 group id。
         out_group_ids[id] = num_inserted_ + num_pending_appends;
+        // 中文说明：把新 group 的 group id 写进当前空槽。
         insert_into_empty_slot(inout_next_slot_ids[id], hashes[id], out_group_ids[id]);
+        // 中文说明：保存 hash，保证这个新 key 后续可被查找和迁移。
         this->hashes()[inout_next_slot_ids[id]] = hashes[id];
+        // 中文说明：row 内容进入 pending append，稍后批量复制到 rows_。
         append_ids[num_pending_appends++] = static_cast<uint16_t>(id);
 
         // We need to break processing and have the caller of this function resize hash
         // table if we reach the limit of the number of groups present.
+        // 中文说明：提交这个新 group 后如果容量满了，就停止本轮 ordered commit。
         if (num_inserted_ + num_pending_appends == num_groups_limit) {
+          // 中文说明：当前 selection 位置已经处理完成，剩余项从下一个位置开始保留。
           ++num_committed;
+          // 中文说明：标记达到容量上限，后面会让调用方扩容。
           reached_capacity = true;
         }
+        // 中文说明：当前 row 已经作为新 group 处理完，退出 inner probing 循环。
         break;
       }
 
@@ -662,28 +726,40 @@ Status SwissTable::map_new_keys_helper(
       // visible before running equality comparison.
       // 中文说明：如果当前 key 撞到了本轮刚插入的 key，必须先 flush，
       // 否则 rows_ 里还没有可供 equal_impl 比较的内容。
+      // 中文说明：把 pending row 写入 rows_，确保 equal_impl 能比较真实 key。
       RETURN_NOT_OK(flush_appends());
+      // 中文说明：run_comparisons 接口接收 selection 数组，这里构造单元素数组。
       uint16_t temp_id = static_cast<uint16_t>(id);
+      // 中文说明：接收比较失败的数量；0 表示当前 key 找到了等价 group。
       int num_not_equal;
+      // 中文说明：只比较当前一个 row 和刚找到的候选 group。
       run_comparisons(1, &temp_id, nullptr, out_group_ids, &num_not_equal, &temp_id,
                       equal_impl, callback_ctx);
+      // 中文说明：比较相等时，group id 已经在 out_group_ids[id] 中，当前 row 完成。
       if (num_not_equal == 0) {
+        // 中文说明：退出 inner 循环，外层继续处理下一个 selection 位置。
         break;
       }
     }
 
+    // 中文说明：容量满时不能继续提交更多 group，要回到调用方扩容。
     if (reached_capacity) {
+      // 中文说明：停止 ordered commit pass，保留剩余 selection。
       break;
     }
   }
+  // 中文说明：把 ordered pass 最后攒下的 pending row 全部写入 rows_。
   RETURN_NOT_OK(flush_appends());
 
   // 中文说明：如果因为容量限制中断，本轮没处理完的 selection 要搬到前面。
   // 调用方扩容后会继续处理这些剩余 key。
+  // 中文说明：只有没有完全处理完 selection 时，才需要压缩剩余项。
   if (num_committed < *inout_num_selected) {
+    // 中文说明：把未处理的 selection 前移到数组开头，供下一轮继续使用。
     memmove(inout_selection, inout_selection + num_committed,
             sizeof(uint16_t) * (*inout_num_selected - num_committed));
   }
+  // 中文说明：更新 selection 长度，只留下尚未处理的 key 数量。
   *inout_num_selected = *inout_num_selected - num_committed;
 
   *out_need_resize = (num_inserted_ == num_groups_limit);

--- a/cpp/src/arrow/compute/key_map_internal.cc
+++ b/cpp/src/arrow/compute/key_map_internal.cc
@@ -530,6 +530,10 @@ Status SwissTable::map_new_keys_helper(
       temp_stack, static_cast<uint32_t>(num_bytes_for_bits));
   uint8_t* match_bitvector = match_bitvector_buf.mutable_data();
   memset(match_bitvector, 0, num_bytes_for_bits);
+  auto committed_bitvector_buf = util::TempVectorHolder<uint8_t>(
+      temp_stack, static_cast<uint32_t>(num_bytes_for_bits));
+  uint8_t* committed_bitvector = committed_bitvector_buf.mutable_data();
+  memset(committed_bitvector, 0, num_bytes_for_bits);
 
   // Check the alignment of the input selection vector
   ARROW_DCHECK((reinterpret_cast<uint64_t>(inout_selection) & 1) == 0);
@@ -537,19 +541,55 @@ Status SwissTable::map_new_keys_helper(
   auto id_to_pos_buffer =
       util::TempVectorHolder<uint16_t>(temp_stack, 1 << log_minibatch_);
   uint16_t* id_to_pos = id_to_pos_buffer.mutable_data();
+  auto append_ids_buffer =
+      util::TempVectorHolder<uint16_t>(temp_stack, *inout_num_selected);
+  uint16_t* append_ids = append_ids_buffer.mutable_data();
+  uint32_t num_pending_appends = 0;
 
-  uint32_t num_processed = *inout_num_selected;
-  for (uint32_t i = 0; i < num_processed; ++i) {
+  auto flush_appends = [&]() -> Status {
+    if (num_pending_appends == 0) {
+      return Status::OK();
+    }
+    RETURN_NOT_OK(append_impl(num_pending_appends, append_ids, callback_ctx));
+    num_inserted_ += num_pending_appends;
+    num_pending_appends = 0;
+    return Status::OK();
+  };
+
+  bool has_pending_match = false;
+  bool reached_capacity = false;
+  uint32_t num_processed = 0;
+  for (; num_processed < *inout_num_selected; ++num_processed) {
     // row id in original batch
-    int id = inout_selection[i];
-    id_to_pos[id] = static_cast<uint16_t>(i);
+    int id = inout_selection[num_processed];
+    id_to_pos[id] = static_cast<uint16_t>(num_processed);
     bool match_found =
         find_next_stamp_match(hashes[id], inout_next_slot_ids[id],
                               &inout_next_slot_ids[id], &out_group_ids[id]);
     if (match_found) {
-      ::arrow::bit_util::SetBit(match_bitvector, i);
+      ::arrow::bit_util::SetBit(match_bitvector, num_processed);
+      has_pending_match = true;
+      continue;
+    }
+
+    // Before any unresolved stamp match, immediate insertion cannot overtake an
+    // earlier key. This keeps the common path close to the original single-pass insert
+    // behavior, while later rows still use ordered commit once a pending match appears.
+    if (!has_pending_match) {
+      out_group_ids[id] = num_inserted_ + num_pending_appends;
+      insert_into_empty_slot(inout_next_slot_ids[id], hashes[id], out_group_ids[id]);
+      this->hashes()[inout_next_slot_ids[id]] = hashes[id];
+      append_ids[num_pending_appends++] = static_cast<uint16_t>(id);
+      ::arrow::bit_util::SetBit(committed_bitvector, num_processed);
+
+      if (num_inserted_ + num_pending_appends == num_groups_limit) {
+        ++num_processed;
+        reached_capacity = true;
+        break;
+      }
     }
   }
+  RETURN_NOT_OK(flush_appends());
 
   auto temp_ids_buffer =
       util::TempVectorHolder<uint16_t>(temp_stack, *inout_num_selected);
@@ -566,21 +606,6 @@ Status SwissTable::map_new_keys_helper(
     ::arrow::bit_util::ClearBit(match_bitvector, id_to_pos[temp_ids[i]]);
   }
 
-  auto append_ids_buffer =
-      util::TempVectorHolder<uint16_t>(temp_stack, *inout_num_selected);
-  uint16_t* append_ids = append_ids_buffer.mutable_data();
-  uint32_t num_pending_appends = 0;
-
-  auto flush_appends = [&]() -> Status {
-    if (num_pending_appends == 0) {
-      return Status::OK();
-    }
-    RETURN_NOT_OK(append_impl(num_pending_appends, append_ids, callback_ctx));
-    num_inserted_ += num_pending_appends;
-    num_pending_appends = 0;
-    return Status::OK();
-  };
-
   const int num_groupid_bits = num_groupid_bits_from_log_blocks(log_blocks_);
   const int num_block_bytes = num_block_bytes_from_num_groupid_bits(num_groupid_bits);
   auto slot_is_empty = [&](uint32_t slot_id) {
@@ -589,9 +614,9 @@ Status SwissTable::map_new_keys_helper(
   };
 
   uint32_t num_committed = 0;
-  bool reached_capacity = false;
   for (; num_committed < num_processed; ++num_committed) {
-    if (::arrow::bit_util::GetBit(match_bitvector, num_committed)) {
+    if (::arrow::bit_util::GetBit(match_bitvector, num_committed) ||
+        ::arrow::bit_util::GetBit(committed_bitvector, num_committed)) {
       continue;
     }
 

--- a/cpp/src/arrow/compute/key_map_internal.cc
+++ b/cpp/src/arrow/compute/key_map_internal.cc
@@ -535,6 +535,7 @@ Status SwissTable::map_new_keys_helper(
   ARROW_DCHECK((reinterpret_cast<uint64_t>(inout_selection) & 1) == 0);
 
   uint32_t num_inserted_new = 0;
+  bool has_pending_match = false;
   uint32_t num_processed;
   for (num_processed = 0; num_processed < *inout_num_selected; ++num_processed) {
     // row id in original batch
@@ -542,22 +543,32 @@ Status SwissTable::map_new_keys_helper(
     bool match_found =
         find_next_stamp_match(hashes[id], inout_next_slot_ids[id],
                               &inout_next_slot_ids[id], &out_group_ids[id]);
-    if (!match_found) {
-      // If we reach the empty slot we insert key for new group
-      //
-      out_group_ids[id] = num_inserted_ + num_inserted_new;
-      insert_into_empty_slot(inout_next_slot_ids[id], hashes[id], out_group_ids[id]);
-      this->hashes()[inout_next_slot_ids[id]] = hashes[id];
-      ::arrow::bit_util::ClearBit(match_bitvector, num_processed);
-      ++num_inserted_new;
+    if (match_found) {
+      has_pending_match = true;
+      continue;
+    }
 
-      // We need to break processing and have the caller of this function resize hash
-      // table if we reach the limit of the number of groups present.
-      //
-      if (num_inserted_ + num_inserted_new == num_groups_limit) {
-        ++num_processed;
-        break;
-      }
+    // Do not let later insertions overtake an earlier key whose stamp match still
+    // needs an equality comparison. If the pending match turns out to be a false
+    // positive, it must get its new group id before later input rows.
+    if (has_pending_match) {
+      break;
+    }
+
+    // If we reach the empty slot we insert key for new group
+    //
+    out_group_ids[id] = num_inserted_ + num_inserted_new;
+    insert_into_empty_slot(inout_next_slot_ids[id], hashes[id], out_group_ids[id]);
+    this->hashes()[inout_next_slot_ids[id]] = hashes[id];
+    ::arrow::bit_util::ClearBit(match_bitvector, num_processed);
+    ++num_inserted_new;
+
+    // We need to break processing and have the caller of this function resize hash
+    // table if we reach the limit of the number of groups present.
+    //
+    if (num_inserted_ + num_inserted_new == num_groups_limit) {
+      ++num_processed;
+      break;
     }
   }
 

--- a/cpp/src/arrow/compute/key_map_internal.cc
+++ b/cpp/src/arrow/compute/key_map_internal.cc
@@ -529,238 +529,112 @@ Status SwissTable::map_new_keys_helper(
   //
   ARROW_DCHECK(*inout_num_selected <= static_cast<uint32_t>(1 << log_minibatch_));
 
-  size_t num_bytes_for_bits = (*inout_num_selected + 7) / 8 + bytes_status_in_block_;
-  auto match_bitvector_buf = util::TempVectorHolder<uint8_t>(
-      temp_stack, static_cast<uint32_t>(num_bytes_for_bits));
-  uint8_t* match_bitvector = match_bitvector_buf.mutable_data();
-  // 中文说明：初始化为 0，表示当前还没有任何行被标记为“候选 match”。
-  memset(match_bitvector, 0, num_bytes_for_bits);
-  // 中文说明：match_bitvector 标记“找到了候选槽，仍需 equal_impl 确认”的
-  // 行；committed_bitvector 标记“已经按输入顺序分配过 group id”的行。
-  // 中文说明：为“已经提交过”的行申请一个 bitset，避免 ordered pass 重复处理。
-  auto committed_bitvector_buf = util::TempVectorHolder<uint8_t>(
-      // 中文说明：这个 bitset 和 match_bitvector 覆盖同一批 selection 位置。
-      temp_stack, static_cast<uint32_t>(num_bytes_for_bits));
-  // 中文说明：拿到 committed bitset 的可写指针，后面按 position 标记。
-  uint8_t* committed_bitvector = committed_bitvector_buf.mutable_data();
-  // 中文说明：初始时没有任何行被提交，所以全部清零。
-  memset(committed_bitvector, 0, num_bytes_for_bits);
-
   // Check the alignment of the input selection vector
   ARROW_DCHECK((reinterpret_cast<uint64_t>(inout_selection) & 1) == 0);
 
-  // 中文说明：给每个原始 batch row id 记录它在当前 selection 里的位置。
-  auto id_to_pos_buffer =
-      // 中文说明：row id 的最大范围由 minibatch 限制，和旧实现的临时数组一致。
-      util::TempVectorHolder<uint16_t>(temp_stack, 1 << log_minibatch_);
-  // 中文说明：后面 equal_impl 返回 row id 后，需要用它反查 selection position。
-  uint16_t* id_to_pos = id_to_pos_buffer.mutable_data();
-  // 中文说明：保存本轮准备追加到 rows_ 的 row id，便于批量 append。
+  // 中文说明：只需要保存本轮会追加的新 key 的 row id，容量取 selection 大小。
   auto append_ids_buffer =
-      // 中文说明：最多只会追加当前 selection 里的这些行，所以容量取 selection 大小。
       util::TempVectorHolder<uint16_t>(temp_stack, *inout_num_selected);
-  // 中文说明：append_impl 需要的是 uint16_t row id 数组。
+  // 中文说明：append_impl 接收裸指针，这里取出临时缓冲的可写地址。
   uint16_t* append_ids = append_ids_buffer.mutable_data();
-  // 中文说明：记录 append_ids 里已经攒了多少个待追加 row。
+  // 中文说明：记录当前攒了多少个尚未真正写入 rows_ 的新 group。
   uint32_t num_pending_appends = 0;
 
-  // 中文说明：新 key 先写入哈希表元数据，但真正把 row 内容追加到 rows_
-  // 里可以批量做。只有当后续比较需要“看见”这些新 row 时，才 flush。
-  // 中文说明：定义一个局部 flush 函数，统一处理“批量追加并推进 num_inserted_”。
+  // Keep appends batched for the common all-new path. Flush only when a later
+  // comparison needs to read a group inserted earlier in this helper call.
+  // 中文说明：按输入顺序先给新 key 分配 group id；row 内容仍批量追加，只有
+  // 比较到本轮刚插入的 group 时才 flush，避免 all-new 路径退化成逐行 append。
   auto flush_appends = [&]() -> Status {
-    // 中文说明：没有待追加 row 时直接返回，避免空 append。
+    // 中文说明：没有 pending append 时直接返回，避免空 append 调用。
     if (num_pending_appends == 0) {
-      // 中文说明：空 flush 是正常路径，返回 OK。
+      // 中文说明：空 flush 是正常路径，不代表错误。
       return Status::OK();
     }
     // 中文说明：把 pending row 真正复制到 rows_，让后续比较能读到 key 内容。
     RETURN_NOT_OK(append_impl(num_pending_appends, append_ids, callback_ctx));
-    // 中文说明：这些 row 已经成为正式 group，所以全局 inserted 计数前移。
+    // 中文说明：这些 pending row 已经成为正式 group，全局 inserted 计数前移。
     num_inserted_ += num_pending_appends;
-    // 中文说明：清空 pending 数量，后续可以复用 append_ids 缓冲。
+    // 中文说明：清空 pending 数量，后续继续复用 append_ids 缓冲。
     num_pending_appends = 0;
-    // 中文说明：flush 成功结束。
+    // 中文说明：flush 成功完成。
     return Status::OK();
   };
 
-  // 中文说明：一旦前面出现了待比较的候选 match，后面的新 key 就不能抢先提交。
-  bool has_pending_match = false;
-  // 中文说明：记录是否因为达到 resize 阈值而提前停止本轮处理。
-  bool reached_capacity = false;
-  // 中文说明：记录已经完成初始探测的 selection 前缀长度。
+  // 中文说明：记录 selection 前缀里已经完成判定的 row 数量。
   uint32_t num_processed = 0;
-  // 中文说明：第一阶段顺序扫描 selection，先区分“候选 match”和“确定新 key”。
-  for (; num_processed < *inout_num_selected; ++num_processed) {
-    // row id in original batch
+  // 中文说明：第一性原理版本只保留一个顺序循环，严格按 selection 顺序决定每个 key。
+  for (; num_processed < *inout_num_selected;) {
+    // 中文说明：selection 里保存的是原始 minibatch row id。
     int id = inout_selection[num_processed];
-    // 中文说明：记住 row id 到 selection 位置的映射，便于比较失败后清 match 位。
-    id_to_pos[id] = static_cast<uint16_t>(num_processed);
-    bool match_found =
-        find_next_stamp_match(hashes[id], inout_next_slot_ids[id],
-                              &inout_next_slot_ids[id], &out_group_ids[id]);
-    // 中文说明：如果 stamp 命中，先标为候选 match，等 equal_impl 真正比较。
-    if (match_found) {
-      // 中文说明：用 selection 位置标记，而不是用原始 row id 标记。
-      ::arrow::bit_util::SetBit(match_bitvector, num_processed);
-      // 中文说明：后续新 key 必须等这个候选 match 判定完，不能越过它分配 group id。
-      has_pending_match = true;
-      // 中文说明：候选 match 暂时不插入，继续扫描后面的 selection 项。
-      continue;
-    }
 
-    // Before any unresolved stamp match, immediate insertion cannot overtake an
-    // earlier key. This keeps the common path close to the original single-pass insert
-    // behavior, while later rows still use ordered commit once a pending match appears.
-    // 中文说明：在遇到第一个待比较的候选 match 之前，前面的 key 都已经确定
-    // 没有被更早的 key 阻塞，所以可以沿用快路径直接插入。
-    // 中文说明：只有没有 pending match 时，当前新 key 才能立即提交。
-    if (!has_pending_match) {
-      // 中文说明：group id 等于已有 group 数加上本批还没 flush 的 pending 个数。
-      out_group_ids[id] = num_inserted_ + num_pending_appends;
-      // 中文说明：把这个新 group 写进哈希表空槽，后续同 batch 的重复 key 能找到它。
-      insert_into_empty_slot(inout_next_slot_ids[id], hashes[id], out_group_ids[id]);
-      // 中文说明：保存完整 hash，供后续 probing / grow 时使用。
-      this->hashes()[inout_next_slot_ids[id]] = hashes[id];
-      // 中文说明：row 内容先记录到 pending append，等 flush 时批量复制到 rows_。
-      append_ids[num_pending_appends++] = static_cast<uint16_t>(id);
-      // 中文说明：这个 selection 位置已经分配过 group id，ordered pass 需要跳过。
-      ::arrow::bit_util::SetBit(committed_bitvector, num_processed);
-
-      // 中文说明：如果 pending append 后达到 resize 阈值，本轮到此为止。
-      if (num_inserted_ + num_pending_appends == num_groups_limit) {
-        // 中文说明：当前行已经处理完，所以 num_processed 前移到下一项。
-        ++num_processed;
-        // 中文说明：通知后面的逻辑和调用方，这次停止是因为容量上限。
-        reached_capacity = true;
-        // 中文说明：跳出第一阶段扫描，剩余 selection 留给扩容后继续处理。
-        break;
-      }
-    }
-  }
-  // 中文说明：第一阶段直接插入的 row 要先落到 rows_，后续比较可能依赖它们。
-  RETURN_NOT_OK(flush_appends());
-
-  auto temp_ids_buffer =
-      util::TempVectorHolder<uint16_t>(temp_stack, *inout_num_selected);
-  uint16_t* temp_ids = temp_ids_buffer.mutable_data();
-  int num_temp_ids = 0;
-
-  // Evaluate comparisons for rows with a matching stamp. Rows that fail comparison
-  // become new-key candidates and must be committed in the original input order.
-  // 中文说明：stamp 命中只代表 hash 层面可能相同。equal_impl 比较失败的行
-  // 仍然是新 key，需要清掉 match 位，交给下面的 ordered commit pass。
-  util::bit_util::bits_filter_indexes(1, hardware_flags_, num_processed, match_bitvector,
-                                      inout_selection, &num_temp_ids, temp_ids);
-  run_comparisons(num_temp_ids, temp_ids, nullptr, out_group_ids, &num_temp_ids, temp_ids,
-                  equal_impl, callback_ctx);
-  // 中文说明：run_comparisons 返回的是“不相等”的 row id，这些要转成新 key 处理。
-  for (int i = 0; i < num_temp_ids; ++i) {
-    // 中文说明：比较失败说明并非已有 key，清掉 match 位让 ordered pass 提交它。
-    ::arrow::bit_util::ClearBit(match_bitvector, id_to_pos[temp_ids[i]]);
-  }
-
-  // 中文说明：计算当前哈希表 block 中 group id 字段占多少 bit。
-  const int num_groupid_bits = num_groupid_bits_from_log_blocks(log_blocks_);
-  // 中文说明：由 group id bit 数推导每个 block 的字节数，用于直接读控制字节。
-  const int num_block_bytes = num_block_bytes_from_num_groupid_bits(num_groupid_bits);
-  // 中文说明：封装一个判断槽位是否为空的小函数，避免对空槽继续找 match。
-  auto slot_is_empty = [&](uint32_t slot_id) {
-    // 中文说明：slot_id 先换算到 block 起始地址。
-    const uint8_t* blockbase = block_data(slot_id >> kLogSlotsPerBlock, num_block_bytes);
-    // 中文说明：控制字节 0x80 表示 empty slot。
-    return blockbase[kMaxLocalSlot - (slot_id & kLocalSlotMask)] == 0x80;
-  };
-
-  // 中文说明：记录 ordered commit pass 已经推进到 selection 的哪个位置。
-  uint32_t num_committed = 0;
-  // 中文说明：从 selection 的第 0 个位置开始顺序提交，这就是保序的关键。
-  // 已经确认匹配旧 key 的行跳过；未匹配的行才按当前位置分配新的 group id。
-  // 中文说明：第二阶段按 selection 物理顺序提交，防止后面的 key 提前拿 group id。
-  for (; num_committed < num_processed; ++num_committed) {
-    // 中文说明：已确认匹配或第一阶段已提交的行，都不需要再次分配 group id。
-    if (::arrow::bit_util::GetBit(match_bitvector, num_committed) ||
-        ::arrow::bit_util::GetBit(committed_bitvector, num_committed)) {
-      // 中文说明：跳过当前位置，继续看下一个 first-seen 顺序位置。
-      continue;
-    }
-
-    // 中文说明：取出当前 selection 位置对应的原始 batch row id。
-    int id = inout_selection[num_committed];
-    // 中文说明：当前 key 可能连续遇到多个 hash stamp 候选，需要循环确认。
+    // 中文说明：同一个 key 可能连续遇到多个 stamp 相同但内容不同的候选 group。
     for (;;) {
-      // 中文说明：本轮循环先假设没有找到真正 match。
-      bool match_found = false;
-      // 中文说明：如果当前槽已经是空槽，就不需要再调用 find_next_stamp_match。
-      if (!slot_is_empty(inout_next_slot_ids[id])) {
-        // 中文说明：沿 probing 链继续找下一个 stamp 相同的候选槽。
-        match_found =
-            find_next_stamp_match(hashes[id], inout_next_slot_ids[id],
-                                  &inout_next_slot_ids[id], &out_group_ids[id]);
-      }
-      // 中文说明：没有候选 match 时，当前 key 确认为新 group。
+      // 中文说明：沿 probing 链查找下一个 stamp 匹配的候选槽；找不到就是新 key。
+      bool match_found =
+          find_next_stamp_match(hashes[id], inout_next_slot_ids[id],
+                                &inout_next_slot_ids[id], &out_group_ids[id]);
+      // 中文说明：没有候选 match 时，当前 key 在当前位置按输入顺序创建新 group。
       if (!match_found) {
-        // If we reach the empty slot we insert key for new group.
-        // 中文说明：严格在当前 selection 位置分配下一个 group id。
+        // 中文说明：新 group id 等于已落盘 group 数加上本轮 pending group 数。
         out_group_ids[id] = num_inserted_ + num_pending_appends;
-        // 中文说明：把新 group 的 group id 写进当前空槽。
+        // 中文说明：把新 group id 写入当前空槽，让后续同 batch 重复 key 能找到它。
         insert_into_empty_slot(inout_next_slot_ids[id], hashes[id], out_group_ids[id]);
-        // 中文说明：保存 hash，保证这个新 key 后续可被查找和迁移。
+        // 中文说明：保存完整 hash，供后续 probing、比较和 grow 迁移使用。
         this->hashes()[inout_next_slot_ids[id]] = hashes[id];
-        // 中文说明：row 内容进入 pending append，稍后批量复制到 rows_。
+        // 中文说明：row 内容先记录到 pending append，等待批量写入 rows_。
         append_ids[num_pending_appends++] = static_cast<uint16_t>(id);
+        // 中文说明：当前 selection 项已经完成判定，前缀长度前移一位。
+        ++num_processed;
 
-        // We need to break processing and have the caller of this function resize hash
-        // table if we reach the limit of the number of groups present.
-        // 中文说明：提交这个新 group 后如果容量满了，就停止本轮 ordered commit。
+        // 中文说明：如果这个新 group 让表达到 resize 阈值，本轮到此停止。
         if (num_inserted_ + num_pending_appends == num_groups_limit) {
-          // 中文说明：当前 selection 位置已经处理完成，剩余项从下一个位置开始保留。
-          ++num_committed;
-          // 中文说明：标记达到容量上限，后面会让调用方扩容。
-          reached_capacity = true;
+          // 中文说明：跳出当前 key 的 probing 循环，外层会保留剩余 selection。
+          break;
         }
-        // 中文说明：当前 row 已经作为新 group 处理完，退出 inner probing 循环。
+        // 中文说明：当前 key 已作为新 group 处理完，继续下一个 selection 项。
         break;
       }
 
-      // A match may point at a key inserted earlier in this commit pass. Make its row
-      // visible before running equality comparison.
-      // 中文说明：如果当前 key 撞到了本轮刚插入的 key，必须先 flush，
-      // 否则 rows_ 里还没有可供 equal_impl 比较的内容。
-      // 中文说明：把 pending row 写入 rows_，确保 equal_impl 能比较真实 key。
-      RETURN_NOT_OK(flush_appends());
-      // 中文说明：run_comparisons 接口接收 selection 数组，这里构造单元素数组。
+      // If the matched group was inserted in this helper call, make its row visible
+      // before comparing. Existing groups are already present in rows_.
+      if (out_group_ids[id] >= num_inserted_) {
+        // 中文说明：候选 group 属于本轮 pending append，先 flush 才能比较真实 row。
+        RETURN_NOT_OK(flush_appends());
+      }
+
+      // 中文说明：run_comparisons 接收 row id 数组，这里构造单元素输入。
       uint16_t temp_id = static_cast<uint16_t>(id);
-      // 中文说明：接收比较失败的数量；0 表示当前 key 找到了等价 group。
+      // 中文说明：接收“不相等”的数量；0 表示当前 key 命中已有 group。
       int num_not_equal;
-      // 中文说明：只比较当前一个 row 和刚找到的候选 group。
+      // 中文说明：只比较当前 row 和刚找到的候选 group。
       run_comparisons(1, &temp_id, nullptr, out_group_ids, &num_not_equal, &temp_id,
                       equal_impl, callback_ctx);
-      // 中文说明：比较相等时，group id 已经在 out_group_ids[id] 中，当前 row 完成。
+      // 中文说明：比较相等时，out_group_ids[id] 已经是正确 group id。
       if (num_not_equal == 0) {
-        // 中文说明：退出 inner 循环，外层继续处理下一个 selection 位置。
+        // 中文说明：当前 selection 项已经完成判定，继续下一个输入位置。
+        ++num_processed;
+        // 中文说明：退出当前 key 的 probing 循环。
         break;
       }
     }
 
-    // 中文说明：容量满时不能继续提交更多 group，要回到调用方扩容。
-    if (reached_capacity) {
-      // 中文说明：停止 ordered commit pass，保留剩余 selection。
+    // 中文说明：容量满时不能继续创建新 group，剩余 key 交给扩容后下一轮处理。
+    if (num_inserted_ + num_pending_appends == num_groups_limit) {
       break;
     }
   }
-  // 中文说明：把 ordered pass 最后攒下的 pending row 全部写入 rows_。
+  // 中文说明：本轮结束前把还没落到 rows_ 的新 group 一次性写入。
   RETURN_NOT_OK(flush_appends());
 
   // 中文说明：如果因为容量限制中断，本轮没处理完的 selection 要搬到前面。
   // 调用方扩容后会继续处理这些剩余 key。
-  // 中文说明：只有没有完全处理完 selection 时，才需要压缩剩余项。
-  if (num_committed < *inout_num_selected) {
-    // 中文说明：把未处理的 selection 前移到数组开头，供下一轮继续使用。
-    memmove(inout_selection, inout_selection + num_committed,
-            sizeof(uint16_t) * (*inout_num_selected - num_committed));
+  if (num_processed < *inout_num_selected) {
+    // 中文说明：只保留未处理的 suffix，调用方扩容后会继续处理这些 row。
+    memmove(inout_selection, inout_selection + num_processed,
+            sizeof(uint16_t) * (*inout_num_selected - num_processed));
   }
-  // 中文说明：更新 selection 长度，只留下尚未处理的 key 数量。
-  *inout_num_selected = *inout_num_selected - num_committed;
+  // 中文说明：更新 selection 长度为“还没有处理完”的数量。
+  *inout_num_selected = *inout_num_selected - num_processed;
 
   *out_need_resize = (num_inserted_ == num_groups_limit);
   return Status::OK();

--- a/cpp/src/arrow/compute/key_map_internal.cc
+++ b/cpp/src/arrow/compute/key_map_internal.cc
@@ -586,12 +586,8 @@ Status SwissTable::map_new_keys_helper(
         // 中文说明：当前 selection 项已经完成判定，前缀长度前移一位。
         ++num_processed;
 
-        // 中文说明：如果这个新 group 让表达到 resize 阈值，本轮到此停止。
-        if (num_inserted_ + num_pending_appends == num_groups_limit) {
-          // 中文说明：跳出当前 key 的 probing 循环，外层会保留剩余 selection。
-          break;
-        }
         // 中文说明：当前 key 已作为新 group 处理完，继续下一个 selection 项。
+        // 是否触发 resize 由外层统一检查，避免这里重复分支。
         break;
       }
 

--- a/cpp/src/arrow/compute/key_map_internal.cc
+++ b/cpp/src/arrow/compute/key_map_internal.cc
@@ -512,6 +512,10 @@ void SwissTable::find(const int num_keys, const uint32_t* hashes,
 // Update selection vector to keep items that were not processed due to resize.
 // Ids in selection vector do not have to be sorted.
 //
+// 中文说明：这里最核心的问题是“group id 的分配顺序”必须跟输入中第一次
+// 看到 key 的顺序一致。探测哈希表时，后面的 key 可能先遇到空槽；如果马上
+// 写入，就可能越过前面仍在等待相等性比较的 key，导致 uniques 顺序被打乱。
+//
 Status SwissTable::map_new_keys_helper(
     const uint32_t* hashes, uint32_t* inout_num_selected, uint16_t* inout_selection,
     bool* out_need_resize, uint32_t* out_group_ids, uint32_t* inout_next_slot_ids,
@@ -530,6 +534,8 @@ Status SwissTable::map_new_keys_helper(
       temp_stack, static_cast<uint32_t>(num_bytes_for_bits));
   uint8_t* match_bitvector = match_bitvector_buf.mutable_data();
   memset(match_bitvector, 0, num_bytes_for_bits);
+  // 中文说明：match_bitvector 标记“找到了候选槽，仍需 equal_impl 确认”的
+  // 行；committed_bitvector 标记“已经按输入顺序分配过 group id”的行。
   auto committed_bitvector_buf = util::TempVectorHolder<uint8_t>(
       temp_stack, static_cast<uint32_t>(num_bytes_for_bits));
   uint8_t* committed_bitvector = committed_bitvector_buf.mutable_data();
@@ -546,6 +552,8 @@ Status SwissTable::map_new_keys_helper(
   uint16_t* append_ids = append_ids_buffer.mutable_data();
   uint32_t num_pending_appends = 0;
 
+  // 中文说明：新 key 先写入哈希表元数据，但真正把 row 内容追加到 rows_
+  // 里可以批量做。只有当后续比较需要“看见”这些新 row 时，才 flush。
   auto flush_appends = [&]() -> Status {
     if (num_pending_appends == 0) {
       return Status::OK();
@@ -575,6 +583,8 @@ Status SwissTable::map_new_keys_helper(
     // Before any unresolved stamp match, immediate insertion cannot overtake an
     // earlier key. This keeps the common path close to the original single-pass insert
     // behavior, while later rows still use ordered commit once a pending match appears.
+    // 中文说明：在遇到第一个待比较的候选 match 之前，前面的 key 都已经确定
+    // 没有被更早的 key 阻塞，所以可以沿用快路径直接插入。
     if (!has_pending_match) {
       out_group_ids[id] = num_inserted_ + num_pending_appends;
       insert_into_empty_slot(inout_next_slot_ids[id], hashes[id], out_group_ids[id]);
@@ -598,6 +608,8 @@ Status SwissTable::map_new_keys_helper(
 
   // Evaluate comparisons for rows with a matching stamp. Rows that fail comparison
   // become new-key candidates and must be committed in the original input order.
+  // 中文说明：stamp 命中只代表 hash 层面可能相同。equal_impl 比较失败的行
+  // 仍然是新 key，需要清掉 match 位，交给下面的 ordered commit pass。
   util::bit_util::bits_filter_indexes(1, hardware_flags_, num_processed, match_bitvector,
                                       inout_selection, &num_temp_ids, temp_ids);
   run_comparisons(num_temp_ids, temp_ids, nullptr, out_group_ids, &num_temp_ids, temp_ids,
@@ -614,6 +626,8 @@ Status SwissTable::map_new_keys_helper(
   };
 
   uint32_t num_committed = 0;
+  // 中文说明：从 selection 的第 0 个位置开始顺序提交，这就是保序的关键。
+  // 已经确认匹配旧 key 的行跳过；未匹配的行才按当前位置分配新的 group id。
   for (; num_committed < num_processed; ++num_committed) {
     if (::arrow::bit_util::GetBit(match_bitvector, num_committed) ||
         ::arrow::bit_util::GetBit(committed_bitvector, num_committed)) {
@@ -646,6 +660,8 @@ Status SwissTable::map_new_keys_helper(
 
       // A match may point at a key inserted earlier in this commit pass. Make its row
       // visible before running equality comparison.
+      // 中文说明：如果当前 key 撞到了本轮刚插入的 key，必须先 flush，
+      // 否则 rows_ 里还没有可供 equal_impl 比较的内容。
       RETURN_NOT_OK(flush_appends());
       uint16_t temp_id = static_cast<uint16_t>(id);
       int num_not_equal;
@@ -662,6 +678,8 @@ Status SwissTable::map_new_keys_helper(
   }
   RETURN_NOT_OK(flush_appends());
 
+  // 中文说明：如果因为容量限制中断，本轮没处理完的 selection 要搬到前面。
+  // 调用方扩容后会继续处理这些剩余 key。
   if (num_committed < *inout_num_selected) {
     memmove(inout_selection, inout_selection + num_committed,
             sizeof(uint16_t) * (*inout_num_selected - num_committed));

--- a/cpp/src/arrow/compute/row/grouper_test.cc
+++ b/cpp/src/arrow/compute/row/grouper_test.cc
@@ -927,22 +927,32 @@ TEST(Grouper, StringKey) {
   }
 }
 
+// 中文说明：这个测试专门覆盖 fast grouper 在字符串 key 上的 first-seen 顺序。
 TEST(Grouper, StringKeyPreservesFirstSeenGroupOrder) {
+  // 中文说明：utf8 和 large_utf8 都走字符串路径，都需要验证保序语义。
   for (auto ty : {utf8(), large_utf8()}) {
+    // 中文说明：失败时打印当前 key 类型，便于区分是哪条类型路径出问题。
     ARROW_SCOPED_TRACE("key type = ", *ty);
     {
+      // 中文说明：新建一个空 Grouper，验证纯新 key 的 group id 分配顺序。
       TestGrouper g({ty});
       // 中文说明：连续的新字符串 key 应该严格按第一次出现的顺序分配
       // group id，并且 uniques 也要保持同样的 first-seen 顺序。
+      // 中文说明：这一行期望 k/l/m/n/o 依次得到 0/1/2/3/4。
       g.ExpectConsume(R"([["k"], ["l"], ["m"], ["n"], ["o"]])", "[0, 1, 2, 3, 4]");
+      // 中文说明：这一行验证 uniques 的物理顺序也保持 k/l/m/n/o。
       g.ExpectUniques(R"([["k"], ["l"], ["m"], ["n"], ["o"]])");
     }
     {
+      // 中文说明：重新建一个空 Grouper，验证重复 key 和新 key 混合时仍然保序。
       TestGrouper g({ty});
       // 中文说明：重复 key 混在新 key 中时，重复项要回到第一次出现的
       // group id；后面的新 key 不能因为哈希探测顺序而提前出现在 uniques 里。
+      // 中文说明：第二个 k 应回到 group 0，最后一个 l 应回到 group 1。
       g.ExpectConsume(R"([["k"], ["l"], ["k"], ["m"], ["n"], ["o"], ["l"]])",
+                      // 中文说明：m/n/o 仍然按第一次出现顺序分到 2/3/4。
                       "[0, 1, 0, 2, 3, 4, 1]");
+      // 中文说明：重复项不应新增 unique，最终仍只保留 k/l/m/n/o。
       g.ExpectUniques(R"([["k"], ["l"], ["m"], ["n"], ["o"]])");
     }
   }

--- a/cpp/src/arrow/compute/row/grouper_test.cc
+++ b/cpp/src/arrow/compute/row/grouper_test.cc
@@ -930,9 +930,17 @@ TEST(Grouper, StringKey) {
 TEST(Grouper, StringKeyPreservesFirstSeenGroupOrder) {
   for (auto ty : {utf8(), large_utf8()}) {
     ARROW_SCOPED_TRACE("key type = ", *ty);
-    TestGrouper g({ty});
-    g.ExpectConsume(R"([["k"], ["l"], ["m"], ["n"], ["o"]])", "[0, 1, 2, 3, 4]");
-    g.ExpectUniques(R"([["k"], ["l"], ["m"], ["n"], ["o"]])");
+    {
+      TestGrouper g({ty});
+      g.ExpectConsume(R"([["k"], ["l"], ["m"], ["n"], ["o"]])", "[0, 1, 2, 3, 4]");
+      g.ExpectUniques(R"([["k"], ["l"], ["m"], ["n"], ["o"]])");
+    }
+    {
+      TestGrouper g({ty});
+      g.ExpectConsume(R"([["k"], ["l"], ["k"], ["m"], ["n"], ["o"], ["l"]])",
+                      "[0, 1, 0, 2, 3, 4, 1]");
+      g.ExpectUniques(R"([["k"], ["l"], ["m"], ["n"], ["o"]])");
+    }
   }
 }
 

--- a/cpp/src/arrow/compute/row/grouper_test.cc
+++ b/cpp/src/arrow/compute/row/grouper_test.cc
@@ -927,6 +927,15 @@ TEST(Grouper, StringKey) {
   }
 }
 
+TEST(Grouper, StringKeyPreservesFirstSeenGroupOrder) {
+  for (auto ty : {utf8(), large_utf8()}) {
+    ARROW_SCOPED_TRACE("key type = ", *ty);
+    TestGrouper g({ty});
+    g.ExpectConsume(R"([["k"], ["l"], ["m"], ["n"], ["o"]])", "[0, 1, 2, 3, 4]");
+    g.ExpectUniques(R"([["k"], ["l"], ["m"], ["n"], ["o"]])");
+  }
+}
+
 TEST(Grouper, StringViewKey) {
   // Mix inline (<=12 byte) and out-of-line view keys.
   for (auto ty : {utf8_view(), binary_view()}) {

--- a/cpp/src/arrow/compute/row/grouper_test.cc
+++ b/cpp/src/arrow/compute/row/grouper_test.cc
@@ -932,11 +932,15 @@ TEST(Grouper, StringKeyPreservesFirstSeenGroupOrder) {
     ARROW_SCOPED_TRACE("key type = ", *ty);
     {
       TestGrouper g({ty});
+      // 中文说明：连续的新字符串 key 应该严格按第一次出现的顺序分配
+      // group id，并且 uniques 也要保持同样的 first-seen 顺序。
       g.ExpectConsume(R"([["k"], ["l"], ["m"], ["n"], ["o"]])", "[0, 1, 2, 3, 4]");
       g.ExpectUniques(R"([["k"], ["l"], ["m"], ["n"], ["o"]])");
     }
     {
       TestGrouper g({ty});
+      // 中文说明：重复 key 混在新 key 中时，重复项要回到第一次出现的
+      // group id；后面的新 key 不能因为哈希探测顺序而提前出现在 uniques 里。
       g.ExpectConsume(R"([["k"], ["l"], ["k"], ["m"], ["n"], ["o"], ["l"]])",
                       "[0, 1, 0, 2, 3, 4, 1]");
       g.ExpectUniques(R"([["k"], ["l"], ["m"], ["n"], ["o"]])");


### PR DESCRIPTION
## Summary
- Add focused row grouper coverage for first-seen key order on string keys.
- Preserve first-seen group id order inside SwissTable new-key insertion when a pending stamp match requires equality comparison.
- Avoid post-processing GetUniques() with a Take; the row table is populated in the intended group id order directly.

## Validation
- `cmake --build .build-choose-test --target arrow-compute-row-test -j8`
- `.build-choose-test/release/arrow-compute-row-test`
- `cmake --build .build-choose-test --target arrow-compute-aggregate-test -j8`
- `.build-choose-test/release/arrow-compute-aggregate-test`